### PR TITLE
Update Generate19From20TargetData.R

### DIFF
--- a/data-raw/Generate19From20TargetData.R
+++ b/data-raw/Generate19From20TargetData.R
@@ -147,11 +147,11 @@ dataSets = dplyr::filter(dataSets, !is.na(indicator_code) & !is.na(psnu)) %>%
                 Sex          = valid_sexes,
                 KeyPop       = valid_kps,
                 mechanismCode= attribute_option_combo,
-                value        = value, #(if we pulled directly from a data pack this would be different than siteValue, but for OPUs should equal siteValue) 
+                value, #(if we pulled directly from a data pack this would be different than siteValue, but for OPUs should equal siteValue) 
                 org_unit     = org_unit,
-                type         = type_options, #{DSD, TA} -   (NA not valid in our case)
-                siteValue    = value
-                )
+                type         = type_options #{DSD, TA} -   (NA not valid in our case)
+                ) %>% 
+  dplyr::mutate(PSNU = glue::glue("{PSNU} ({psnuid})"), siteValue = value)
 
 
 # Initialize empty result list for performance reasons


### PR DESCRIPTION
Put mismatched records in another object for now, will need to be insetigated case by case.



## Summary of Proposed Changes

Modify code to use results of getSiteList call and SiteToDatim table to go from data value set to data packr `d` object.


## Affected Process Elements
- [ ] Data Pack generation
- [ ] Data Pack model
- [ ] Data Pack self-service app
- [ ] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [X] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
