### PR TITLE
Refactor getValidCos for better clarity.

### DIFF
--- a/R/getValidCOs.R
+++ b/R/getValidCOs.R
@@ -24,9 +24,9 @@ getValidCOs <- function(deg_id = "XUA8pDYjPsw") {
     # TODO generate match automatically based on current FY...
     datapackr::api_fields("dataElements[id~rename(de_id),name~rename(de_name),categoryCombo[categories[id~rename(categoryid),name~rename(categoryname),categoryOptions[id~rename(coid),name~rename(coname)]]]]") %>%
     datapackr::api_get() %>%
-    tidyr::unnest(dataElements)  %>% 
+    tidyr::unnest(cols = dataElements)  %>% 
     tidyr::unnest(cols = categoryCombo.categories) %>% 
-    tidyr::unnest(categoryOptions) %>%
+    tidyr::unnest(cols = categoryOptions) %>%
     dplyr::mutate(
       grp = dplyr::case_when(stringr::str_detect(categoryname, "Age") ~ "Age",
                              stringr::str_detect(categoryname, "Sex") ~ "Sex",

--- a/R/handshakeFile.R
+++ b/R/handshakeFile.R
@@ -53,14 +53,19 @@ handshakeFile <- function(path = NA,
     }
   
   # If path has issues or NA, prompt user to select file from window.
-  if (!canReadFile(path) & interactive()) {
-    interactive_print("Please choose a file.")
-    path <- file.choose()
+  if ( !canReadFile(path) ) {
+    if ( interactive() ) {
+      interactive_print("Please choose a file.")
+      path <- file.choose()
+      
+      if (!canReadFile(path)) {
+        stop("File could not be read!")
+      }
+      
+    } else {
+      stop("File could not be read!")
+    }
     
-    if (!canReadFile(path)) {stop("File could not be read!")}
-    
-  } else {
-    stop("File cannot be read.")
   }
   
   # Check the file has correct extension

--- a/R/handshakeFile.R
+++ b/R/handshakeFile.R
@@ -59,6 +59,8 @@ handshakeFile <- function(path = NA,
     
     if (!canReadFile(path)) {stop("File could not be read!")}
     
+  } else {
+    stop("File cannot be read.")
   }
   
   # Check the file has correct extension


### PR DESCRIPTION
Minor refactor of getValidCos method. 

`unnest` requires the use of a labeled column, so this was added. 

Make better use of the renaming capabilities of the DHIS2 api to avoid problems when unnesting. 