### PR TITLE
rePackSnuxIM stop distribution error if original target <.5

### DIFF
--- a/R/rePackSNUxIM.R
+++ b/R/rePackSNUxIM.R
@@ -34,7 +34,9 @@ rePackPSNUxIM <- function(d) {
   
   # TEST where Data Pack targets not fully distributed.
   undistributed <- d$data$distributedMER %>%
-    dplyr::filter(!is.na(value) & is.na(distribution))
+    dplyr::filter(!is.na(value) & 
+                    value >= .5 & 
+                    is.na(distribution))
   
   if (NROW(undistributed) > 0) {
     d$tests$undistributed <- undistributed


### PR DESCRIPTION
fixes #66

If the value is <.5 this is rounded to 0 in excel and therefore no distribution is "required."