### PR TITLE
Remove all filters when Generating PSNUxIM

### DIFF
--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -109,13 +109,7 @@ packSNUxIM <- function(d) {
         
       # Write data to sheet ####
         d$tool$wb <- openxlsx::loadWorkbook(d$keychain$submission_path)
-        
-        sheets_with_filters <- cop20_data_pack_schema %>%
-          dplyr::filter(data_structure == "normal") %>%
-          dplyr::pull(sheet_num) %>%
-          unique()
-        
-        openxlsx::removeFilter(d$tool$wb, sheets_with_filters)
+        openxlsx::removeFilter(d$tool$wb, names(d$tool$wb))
         
         openxlsx::writeData(wb = d$tool$wb,
                             sheet = "PSNUxIM",

--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -20,8 +20,8 @@ packSNUxIM <- function(d) {
     # If doesn't exist, write all combos in ####
     } else {
       # Prepare SNU x IM model dataset ####
-        snuxim_model_data <- readRDS(d$keychain$snuxim_model_data_path) %>%
-          dplyr::select(-value, -age_option_uid, -sex_option_uid, -kp_option_uid)
+      snuxim_model_data <- readRDS(d$keychain$snuxim_model_data_path)[[d$info$country_uids]] %>%
+        dplyr::select(-value, -age_option_uid, -sex_option_uid, -kp_option_uid)
       
       # Combine with MER data ####
         dsd_ta <- tibble::tribble(


### PR DESCRIPTION


## Summary of Proposed Changes

1) Removes all filters when generating the  SNUxIM tab and saving the output workbook.
2) Uses the country uid from the data pack when pulling data from the SNUxIM distribution file

## Affected Process Elements
- [ ] Data Pack generation
- [ ] Data Pack model
- [ ] Data Pack self-service app
- [x] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [ ] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes

<!--- What types of changes does your code introduce to Appium? --->
<!--- _Put an `x` in the boxes that apply_ --->

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
