### PR TITLE
Handle empty target rows in data pack

### DIFF
--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -21,7 +21,7 @@ unPackDataPackSheet <- function(d, sheet) {
       range = readxl::cell_limits(c(header_row, 1), c(NA, NA)),
       col_types = "text"
     ) %>% 
-  # remove rows
+  # remove rows that are all NAs
     dplyr::filter_all(dplyr::any_vars(!is.na(.)))
 
   # if tab has no target related content, send d back

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -20,7 +20,9 @@ unPackDataPackSheet <- function(d, sheet) {
       sheet = sheet,
       range = readxl::cell_limits(c(header_row, 1), c(NA, NA)),
       col_types = "text"
-    )
+    ) %>% 
+  # remove rows
+    dplyr::filter_all(dplyr::any_vars(!is.na(.)))
 
   # if tab has no target related content, send d back
   if (NROW(d$data$extract) == 0) {

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -21,6 +21,12 @@ unPackDataPackSheet <- function(d, sheet) {
       range = readxl::cell_limits(c(header_row, 1), c(NA, NA)),
       col_types = "text"
     )
+
+  # if tab has no target related content, send d back
+  if (NROW(d$data$extract) == 0) {
+    d$data$extract <- NULL
+    return(d)
+    }
   
   # Run structural checks ####
   d <- checkColStructure(d, sheet)


### PR DESCRIPTION
resolves https://github.com/pepfar-datim/COP-Target-Setting/issues/634


## Summary of Proposed Changes

If a data pack sheet has no user content (target rows all deleted), move on to the next sheet without trying to add anything to the d object


## Affected Process Elements
- [] Data Pack generation
- [ ] Data Pack model
- [] Data Pack self-service app
- [X] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [ ] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Related Issues

resolves https://github.com/pepfar-datim/COP-Target-Setting/issues/634

## Testing Approach

Parsed DRC data pack from this ticket: https://datim.zendesk.com/agent/tickets/32017
