### PR TITLE
Allow processing of brand new PSNUxIMs; Fix issues with regional OU processing

### DIFF
--- a/R/unPackTool.R
+++ b/R/unPackTool.R
@@ -51,6 +51,7 @@ unPackTool <- function(submission_path = NULL,
   d$info$has_error <- FALSE
   d$info$newSNUxIM <- FALSE
   d$info$has_psnuxim <- FALSE
+  d$info$missing_psnuxim_combos <- FALSE
   
   # Check the submission file exists and prompt for user input if not
   d$keychain$submission_path <- handshakeFile(path = d$keychain$submission_path,


### PR DESCRIPTION
## Summary of Proposed Changes
- Allows processing of regional OU data packs to write in and append to PSNUxIM tab
- Allows parsing of regional OU data packs, with or without PSNUxIM tabs
- Fixes control flow issues with Data Packs with no PSNUxIM information

## Affected Process Elements
- [x] Data Pack generation
- [ ] Data Pack model
- [ ] Data Pack self-service app
- [x] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [ ] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Final Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
