### PR TITLE
Ensuring the the tests object initializes as a character vector

### DIFF
--- a/R/checkColStructure.R
+++ b/R/checkColStructure.R
@@ -30,6 +30,7 @@ checkColStructure <- function(d, sheet) {
     dplyr::left_join(submission_cols, by = c("indicator_code" = "indicator_code")) %>%
     dplyr::mutate(order_check = template_order == submission_order)
   
+  d[["tests"]][["col_check"]][[as.character(sheet)]] <- character()
   d[["tests"]][["col_check"]][[as.character(sheet)]] <- col_check
   
   # Alert to missing cols ####
@@ -38,7 +39,7 @@ checkColStructure <- function(d, sheet) {
     missing_cols <- col_check %>%
       dplyr::filter(is.na(submission_order)) %>%
       dplyr::pull(indicator_code)
-    
+    d[["tests"]][["missing_cols"]][[as.character(sheet)]]  <- character()
     d[["tests"]][["missing_cols"]][[as.character(sheet)]] <- missing_cols
     
     warning_msg <-
@@ -61,6 +62,7 @@ checkColStructure <- function(d, sheet) {
   duplicate_columns <- submission_cols_no_blanks[duplicated(submission_cols_no_blanks)]
   
   if (length(duplicate_columns) > 0) {
+    d[["tests"]][["duplicate_columns"]][[as.character(sheet)]] <- character()
     d[["tests"]][["duplicate_columns"]][[as.character(sheet)]] <- duplicate_columns
     
     warning_msg <-
@@ -80,6 +82,7 @@ checkColStructure <- function(d, sheet) {
   columns_out_of_order <- col_check[which(col_check$template_order != col_check$submission_order),"indicator_code"]
   
   if ( length(columns_out_of_order) > 0 ) {
+    d[["tests"]][["columns_out_of_order"]][[as.character(sheet)]] <- character()
     d[["tests"]][["columns_out_of_order"]][[as.character(sheet)]] <- columns_out_of_order
     
     warning_msg <-

--- a/R/checkInvalidOrgUnits.R
+++ b/R/checkInvalidOrgUnits.R
@@ -31,6 +31,7 @@ checkInvalidOrgUnits <- function(d, sheet) {
   
   if (length(invalid_orgunits) > 0) {
     
+    d[["tests"]][["invalid_orgunits"]][[as.character(sheet)]] <- character()
     d[["tests"]][["invalid_orgunits"]][[as.character(sheet)]] <- invalid_orgunits
     
     warning_msg <-

--- a/R/checkMissingMetadata.R
+++ b/R/checkMissingMetadata.R
@@ -22,6 +22,7 @@ checkMissingMetadata <- function(d, sheet) {
     dplyr::filter_at(dplyr::vars(dplyr::matches("^PSNU$|^ID$|^indicator_code$")),
                      dplyr::any_vars(is.na(.)))
   
+  d[["tests"]][["missing_metadata"]][[as.character(sheet)]] <- character()
   d[["tests"]][["missing_metadata"]][[as.character(sheet)]] <- missing_metadata
   
   # Alert to missing metadata

--- a/R/defunctDisaggs.R
+++ b/R/defunctDisaggs.R
@@ -34,6 +34,7 @@ defunctDisaggs <- function(d, sheet) {
     dplyr::distinct()
   
   if (NROW(defunct) > 0) {
+    d[["tests"]][["defunct"]][[as.character(sheet)]] <- character()
     d[["tests"]][["defunct"]][[as.character(sheet)]] <- defunct
     
     defunct_msg <- 

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -69,6 +69,7 @@ unPackSNUxIM <- function(d) {
     dplyr::select(-dplyr::matches("(\\d){4,6}_(DSD|TA)")) %>%
     names()
   
+  d[["tests"]][["invalid_mech_headers"]][[as.character(sheet)]] <- character()
   d[["tests"]][["invalid_mech_headers"]][[as.character(sheet)]] <- invalid_mech_headers
   
   if (length(invalid_mech_headers) > 0) {


### PR DESCRIPTION
While unpacking the Mali data pack in this ticket: https://datim.zendesk.com/agent/tickets/32224

I received this error 
```
[1] "GEND"
Error in d[["tests"]][["missing_cols"]][[as.character(sheet)]] <- missing_cols :                                                     
  more elements supplied than there are to replace
> traceback()
4: checkColStructure(d, "PSNUxIM")
3: unPackSNUxIM(d)
2: unPackDataPack(d)
1: unPackTool()
```

This is the same error addressed in: 

https://github.com/pepfar-datim/datapackr/pull/89

The current PR applies this fix broadly across the code base to avoid this error popping up again.