### PR TITLE
Gh661

### DIFF
--- a/R/checkColStructure.R
+++ b/R/checkColStructure.R
@@ -30,6 +30,7 @@ checkColStructure <- function(d, sheet) {
     dplyr::left_join(submission_cols, by = c("indicator_code" = "indicator_code")) %>%
     dplyr::mutate(order_check = template_order == submission_order)
   
+  d[["tests"]][["col_check"]][[as.character(sheet)]] <- character()
   d[["tests"]][["col_check"]][[as.character(sheet)]] <- col_check
   
   # Alert to missing cols ####
@@ -38,7 +39,7 @@ checkColStructure <- function(d, sheet) {
     missing_cols <- col_check %>%
       dplyr::filter(is.na(submission_order)) %>%
       dplyr::pull(indicator_code)
-    
+    d[["tests"]][["missing_cols"]][[as.character(sheet)]]  <- character()
     d[["tests"]][["missing_cols"]][[as.character(sheet)]] <- missing_cols
     
     warning_msg <-
@@ -61,6 +62,7 @@ checkColStructure <- function(d, sheet) {
   duplicate_columns <- submission_cols_no_blanks[duplicated(submission_cols_no_blanks)]
   
   if (length(duplicate_columns) > 0) {
+    d[["tests"]][["duplicate_columns"]][[as.character(sheet)]] <- character()
     d[["tests"]][["duplicate_columns"]][[as.character(sheet)]] <- duplicate_columns
     
     warning_msg <-
@@ -80,6 +82,7 @@ checkColStructure <- function(d, sheet) {
   columns_out_of_order <- col_check[which(col_check$template_order != col_check$submission_order),"indicator_code"]
   
   if ( length(columns_out_of_order) > 0 ) {
+    d[["tests"]][["columns_out_of_order"]][[as.character(sheet)]] <- character()
     d[["tests"]][["columns_out_of_order"]][[as.character(sheet)]] <- columns_out_of_order
     
     warning_msg <-

--- a/R/checkInvalidOrgUnits.R
+++ b/R/checkInvalidOrgUnits.R
@@ -31,6 +31,7 @@ checkInvalidOrgUnits <- function(d, sheet) {
   
   if (length(invalid_orgunits) > 0) {
     
+    d[["tests"]][["invalid_orgunits"]][[as.character(sheet)]] <- character()
     d[["tests"]][["invalid_orgunits"]][[as.character(sheet)]] <- invalid_orgunits
     
     warning_msg <-

--- a/R/checkMissingMetadata.R
+++ b/R/checkMissingMetadata.R
@@ -22,6 +22,7 @@ checkMissingMetadata <- function(d, sheet) {
     dplyr::filter_at(dplyr::vars(dplyr::matches("^PSNU$|^ID$|^indicator_code$")),
                      dplyr::any_vars(is.na(.)))
   
+  d[["tests"]][["missing_metadata"]][[as.character(sheet)]] <- character()
   d[["tests"]][["missing_metadata"]][[as.character(sheet)]] <- missing_metadata
   
   # Alert to missing metadata

--- a/R/defunctDisaggs.R
+++ b/R/defunctDisaggs.R
@@ -34,6 +34,7 @@ defunctDisaggs <- function(d, sheet) {
     dplyr::distinct()
   
   if (NROW(defunct) > 0) {
+    d[["tests"]][["defunct"]][[as.character(sheet)]] <- character()
     d[["tests"]][["defunct"]][[as.character(sheet)]] <- defunct
     
     defunct_msg <- 

--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -12,7 +12,9 @@
 packSNUxIM <- function(d) {
   if ( d$info$cop_year == 2020 ) {
   # Check if SNUxIM data already exists ####
-    d$info$has_psnuxim <- (NROW(d$data$SNUxIM) > 0)
+    if (NROW(d$data$SNUxIM) == 1 & is.na(d$data$SNUxIM[[1,1]])) {
+      d$info$has_psnuxim <- FALSE
+    } else {d$info$has_psnuxim <- TRUE}
   
   # If does exist, check what combos are missing ####
     if (d$info$has_psnuxim) {

--- a/R/unPackDataPack.R
+++ b/R/unPackDataPack.R
@@ -64,7 +64,7 @@ unPackDataPack <- function(d) {
     d <- unPackSNUxIM(d)
 
   # Combine Targets with SNU x IM for PSNU x IM level targets ####
-    if (NROW(d$data$SNUxIM) > 0) {
+    if (d$info$has_psnuxim) {
       d <- combineMER_SNUxIM(d)
       
     # Prepare SNU x IM dataset for DATIM import & validation ####

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -29,6 +29,11 @@ unPackSNUxIM <- function(d) {
       .name_repair = "minimal"
     )
   
+  if (NROW(d$data$SNUxIM) == 1 & is.na(d$data$SNUxIM[[1,1]])) {
+    d$info$has_psnuxim <- FALSE
+    return(d)
+  } else {d$info$has_psnuxim <- TRUE}
+  
   # Run structural checks ####
   d <- checkColStructure(d, "PSNUxIM")
   
@@ -48,11 +53,6 @@ unPackSNUxIM <- function(d) {
   
   # Remove rows with NAs in key cols ####
     dplyr::filter_at(dplyr::vars(PSNU, indicator_code, ID), dplyr::any_vars(!is.na(.)))
-  
-  if (NROW(d$data$SNUxIM) == 0) {
-    d$info$has_psnuxim <- FALSE
-    return(d)
-  } else {d$info$has_psnuxim <- TRUE}
   
   # TEST for missing metadata (PSNU, indicator_code, ID) ####
   d <- checkMissingMetadata(d, sheet)

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -69,6 +69,7 @@ unPackSNUxIM <- function(d) {
     dplyr::select(-dplyr::matches("(\\d){4,6}_(DSD|TA)")) %>%
     names()
   
+  d[["tests"]][["invalid_mech_headers"]][[as.character(sheet)]] <- character()
   d[["tests"]][["invalid_mech_headers"]][[as.character(sheet)]] <- invalid_mech_headers
   
   if (length(invalid_mech_headers) > 0) {

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -35,10 +35,7 @@ unPackDataPackSheet <- function(d, sheet) {
   
   # Make sure no blank column names
   d$data$extract %<>%
-    tibble::as_tibble(.name_repair = "unique") %>%
-  
-  # Remove rows that are all NAs
-    dplyr::filter_all(dplyr::any_vars(!is.na(.)))
+    tibble::as_tibble(.name_repair = "unique")
 
   # if tab has no target related content, send d back
   if (NROW(d$data$extract) == 0) {
@@ -48,6 +45,10 @@ unPackDataPackSheet <- function(d, sheet) {
   
   # TEST: No missing metadata ####
   d <- checkMissingMetadata(d, sheet)
+  
+  # If PSNU has been deleted, drop the row
+  d$data$extract %<>%
+    dplyr::filter(!is.na(PSNU))
   
   # TEST TX_NEW <1 from somewhere other than EID ####
   if (sheet == "TX") {


### PR DESCRIPTION
## Summary of Proposed Changes
- Drop rows with missing PSNUs after alerting. This is to accommodate both cases where a user has deleted this critical column, and where users have entered floating data below the bulk of a data sheet.
- Don't run validation checks against blank PSNUxIM tabs. This was raising issues previously that are not valid.

## Affected Process Elements
- [ ] Data Pack generation
- [ ] Data Pack model
- [ ] Data Pack self-service app
- [x] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [ ] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes

<!--- What types of changes does your code introduce to Appium? --->
<!--- _Put an `x` in the boxes that apply_ --->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->