### PR TITLE
imbalanced distribution test fix

### DIFF
--- a/R/combineMER_SNUxIM.R
+++ b/R/combineMER_SNUxIM.R
@@ -58,7 +58,7 @@ combineMER_SNUxIM <- function(d) {
     dplyr::mutate(distributed_value_total = sum(distributed_value),
                   diff = value - distributed_value_total) %>%
     dplyr::ungroup() %>%
-    dplyr::filter(value != round_trunc(distributed_value_total))
+    dplyr::filter(round_trunc(value) != round_trunc(distributed_value_total))
 
   if (NROW(d$tests$imbalancedDistribution) > 0) {
     imbalancedDistribution_inds <- d$tests$imbalancedDistribution %>%


### PR DESCRIPTION
We were comparing a rounded value with an unrounded value. We need to treat LHS and RHS symetrically. NO rounding could lead to floating point differences, so I rounded both.

Before we were getting many errors like this even though the allocation percentages sum to 100% in excel:
'```
5 :  ERROR!: 8207 cases where distributed total across all mechanisms and Dedupe is either more or less than PSNU-level Target. To identify these, go to your PSNUxIM tab and filter the Rollup column to find cases where this is not equal to 100%. NOTE that this may be due to any invalid mechanism names in row 14 of your PSNUxIM tab. For reference, this has affected the following indicators -> 
	* GEND_GBV.N.ViolenceServiceType.T.physEmot
	* GEND_GBV.N.ViolenceServiceType.T.Sexual
	* TB_ART.N.Age_Sex_NewExistingART_HIVStatus.T.Already
	* TB_STAT.N.Age_Sex_KnownNewPosNeg.T.KnownPos
	* TB_STAT.N.Age_Sex_KnownNewPosNeg.T.NewNeg
```


As a side note we coule probably just be checking that the sum of the allocations = 100%
