### PR TITLE
Fix issue writing new mech column labels.

### DIFF
--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -277,7 +277,7 @@ packSNUxIM <- function(d) {
           # Add additional col_names if any
           openxlsx::writeData(wb = d$tool$wb,
                               sheet = "PSNUxIM",
-                              x = new_mech_cols,
+                              x = new_mech_cols %>% as.matrix() %>% t(),
                               xy = c(first_new_mech_col, top_rows),
                               colNames = F, rowNames = F, withFilter = FALSE)
           


### PR DESCRIPTION
Transpose new mech cols column vector into a row vector when writing to the data pack.

If we send openxlsx::writeData a column vector it will write the content vertically. In the case of mechanism column headers we want it written horizontally. So, we need to transpose the column vector of new mechanism names

fixes https://github.com/pepfar-datim/COP-Target-Setting/issues/698