### PR TITLE
Purge code calling deprecated functions

### DIFF
--- a/R/datapackr.R
+++ b/R/datapackr.R
@@ -236,7 +236,6 @@ if (getRversion() >= "2.15.1")
       "type",
       "uid",
       "uidlevel3",
-      "unPackSiteFilter",
       "unPackSiteTool",
       "upload_timestamp",
       "valid_ages",

--- a/R/datapackr.R
+++ b/R/datapackr.R
@@ -104,7 +104,6 @@ if (getRversion() >= "2.15.1")
       "duplicates",
       "effect",
       "enddate",
-      "FASTforward",
       "fiscal_year",
       "formula",
       "formula_15",

--- a/R/datapackr.R
+++ b/R/datapackr.R
@@ -236,7 +236,6 @@ if (getRversion() >= "2.15.1")
       "type",
       "uid",
       "uidlevel3",
-      "unPackSiteTool",
       "upload_timestamp",
       "valid_ages",
       "valid_ages.id",

--- a/R/datapackr.R
+++ b/R/datapackr.R
@@ -237,7 +237,6 @@ if (getRversion() >= "2.15.1")
       "type",
       "uid",
       "uidlevel3",
-      "unPackMechanismMap",
       "unPackSiteFilter",
       "unPackSiteTool",
       "upload_timestamp",

--- a/R/unPackDataPack.R
+++ b/R/unPackDataPack.R
@@ -77,10 +77,6 @@ unPackDataPack <- function(d) {
       
     # Package SUBNAT/IMPATT DATIM import file ####
       d <- packForDATIM(d, type = "SUBNAT_IMPATT")
-      
-    # Package FAST export ####
-      if (d$info$cop_year == 2019) {d <- FASTforward(d)}
-
     }
     
   return(d)

--- a/R/unPackTool.R
+++ b/R/unPackTool.R
@@ -68,8 +68,6 @@ unPackTool <- function(submission_path = NULL,
   # unPack file based on type
   if (d$info$tool == "Data Pack") {
     d <- unPackDataPack(d)
-  } else if (d$info$tool == "Site Tool") {
-    d <- unPackSiteTool(d)
   } else {stop("Please select correct file type: Data Pack, Site Tool, Mechanism Map, or Site Filter.")}
   
   # If warnings, show all grouped by sheet and issue

--- a/R/unPackTool.R
+++ b/R/unPackTool.R
@@ -70,8 +70,6 @@ unPackTool <- function(submission_path = NULL,
     d <- unPackDataPack(d)
   } else if (d$info$tool == "Site Tool") {
     d <- unPackSiteTool(d)
-  } else if (d$info$tool == "Site Filter") {
-    d <- unPackSiteFilter(d)
   } else {stop("Please select correct file type: Data Pack, Site Tool, Mechanism Map, or Site Filter.")}
   
   # If warnings, show all grouped by sheet and issue

--- a/R/unPackTool.R
+++ b/R/unPackTool.R
@@ -70,8 +70,6 @@ unPackTool <- function(submission_path = NULL,
     d <- unPackDataPack(d)
   } else if (d$info$tool == "Site Tool") {
     d <- unPackSiteTool(d)
-  } else if (d$info$tool == "Mechanism Map") {
-    d <- unPackMechanismMap(d)
   } else if (d$info$tool == "Site Filter") {
     d <- unPackSiteFilter(d)
   } else {stop("Please select correct file type: Data Pack, Site Tool, Mechanism Map, or Site Filter.")}


### PR DESCRIPTION
@jacksonsj I still found function calls and variable definitions for unPackMechanismMap, FASTforward, unPackSiteFilter, and unpackSiteTool.

additional cleanup related to:
unPackMechanismMap, FASTforward, unPackSiteFilter, and unpackSiteTool.

see https://github.com/pepfar-datim/COP-Target-Setting/issues/741