### PR TITLE
adornPSNUs bug fix

### DIFF
--- a/R/adornPSNUs.R
+++ b/R/adornPSNUs.R
@@ -14,7 +14,7 @@
 adornPSNUs<-function(d) {
   
   PSNUList <- datapackr::valid_PSNUs %>%
-      dplyr::select(ou, ou_id, country_name, country_uid, snu1, snu1_id, psnu, psnu_uid)
+      dplyr::select(country_name, country_uid, psnu, psnu_uid)
   
   d$data$analytics %<>% dplyr::left_join(PSNUList, by = c("psnuid" = "psnu_uid"))
   

--- a/R/createAnalytics.R
+++ b/R/createAnalytics.R
@@ -51,12 +51,8 @@ createAnalytics <- function(d) {
   ) %>% 
   dplyr::mutate(upload_timestamp = format(Sys.time(),"%Y-%m-%d %H:%M:%S"),
                 fiscal_year = "FY21") %>% 
-    dplyr::select( ou,
-                   ou_id,
-                   country_name,
+    dplyr::select( country_name,
                    country_uid,
-                   snu1,
-                   snu1_id,
                    psnu,
                    psnuid,
                    prioritization,


### PR DESCRIPTION
Seems to fix a bug I was encountering when unpacking a data pack (https://pepfar.sharepoint.com/:x:/r/sites/PRIMEInformationSystems/Shared%20Documents/COP%2020%20Data%20Pack%20Staging%20Area/Misc/Data%20Pack_Rwanda_20200211_v8_snuxim.xlsx?d=w2950849be1ec4c76ba8384fed522e979&csf=1&web=1&e=43JDcx):

```
> d <- unPackTool("~/datapackr_test_files/for_repack_PSNUxIM copy/Data Pack_Rwanda_20200211_v8_snuxim.xlsx")
[1] "Checking for any missing tabs..."                                                                            
[1] "Epi Cascade I"
[1] "Epi PMTCT"                                                                                                   
[1] "Prioritization"                                                                                              
[1] "TX"                                                                                                          
New names:                                                                                                        
* `` -> ...43
[1] "HTS"
[1] "TB_STAT_ART"                                                                                                 
New names:                                                                                                        
* `` -> ...20
[1] "PMTCT_STAT_ART"
[1] "PMTCT_EID"                                                                                                   
[1] "VMMC"                                                                                                        
[1] "CXCA"                                                                                                        
[1] "HTS_RECENT"                                                                                                  
[1] "TX_TB_PREV"                                                                                                  
[1] "KP"                                                                                                          
[1] "PP"                                                                                                          
[1] "OVC"                                                                                                         
[1] "PrEP"                                                                                                        
[1] "GEND"                                                                                                        
New names:                                                                                                        
* `` -> ...7
Error: Can't subset columns that don't exist.                                                                     
x Column `ou` doesn't exist.
Run `rlang::last_error()` to see where the error occurred.
> traceback()
23: stop(fallback)
22: rlang:::signal_abort(x)
21: cnd_signal(cnd)
20: value[[3L]](cond)
19: tryCatchOne(expr, names, parentenv, handlers[[1L]])
18: tryCatchList(expr, classes, parentenv, handlers)
17: tryCatch(instrument_base_errors(expr), vctrs_error_subscript = function(cnd) {
        cnd$subscript_action <- subscript_action(type)
        cnd$subscript_elt <- "column"
        cnd_signal(cnd)
    })
16: with_subscript_errors(vars_select_eval(vars, expr, strict, data = x, 
        name_spec = name_spec, uniquely_named = uniquely_named, allow_rename = allow_rename, 
        type = type), type = type)
15: eval_select_impl(NULL, .vars, expr(c(!!!dots)), include = .include, 
        exclude = .exclude, strict = .strict, name_spec = unique_name_spec, 
        uniquely_named = TRUE)
14: tidyselect::vars_select(tbl_vars(.data), !!!enquos(...))
13: select.data.frame(., ou, ou_id, country_name, country_uid, snu1, 
        snu1_id, psnu, psnuid, prioritization, mechanism_code, mechanism_desc, 
        partner_id, partner_desc, funding_agency = agency, fiscal_year, 
        dataelement_id = dataelement, dataelement_name = dataelement.y, 
        indicator = technical_area, numerator_denominator, support_type, 
        hts_modality, categoryoptioncombo_id = categoryoptioncombouid, 
        categoryoptioncombo_name = categoryoptioncombo, age = Age, 
        sex = Sex, key_population = KeyPop, resultstatus_specific = resultstatus, 
        upload_timestamp, disagg_type, resultstatus_inclusive, top_level, 
        target_value = value, indicator_code)
12: dplyr::select(., ou, ou_id, country_name, country_uid, snu1, 
        snu1_id, psnu, psnuid, prioritization, mechanism_code, mechanism_desc, 
        partner_id, partner_desc, funding_agency = agency, fiscal_year, 
        dataelement_id = dataelement, dataelement_name = dataelement.y, 
        indicator = technical_area, numerator_denominator, support_type, 
        hts_modality, categoryoptioncombo_id = categoryoptioncombouid, 
        categoryoptioncombo_name = categoryoptioncombo, age = Age, 
        sex = Sex, key_population = KeyPop, resultstatus_specific = resultstatus, 
        upload_timestamp, disagg_type, resultstatus_inclusive, top_level, 
        target_value = value, indicator_code)
11: function_list[[k]](value)
10: withVisible(function_list[[k]](value))
9: freduce(value, `_function_list`)
8: `_fseq`(`_lhs`)
7: eval(quote(`_fseq`(`_lhs`)), env, env)
6: eval(quote(`_fseq`(`_lhs`)), env, env)
5: withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
4: d$data$analytics %<>% dplyr::left_join(., (map_DataPack_DATIM_DEs_COCs_local %>% 
       dplyr::rename(Age = valid_ages.name, Sex = valid_sexes.name, 
           KeyPop = valid_kps.name)), by = c("Age", "Sex", "KeyPop", 
       "indicator_code", "support_type")) %>% dplyr::mutate(upload_timestamp = format(Sys.time(), 
       "%Y-%m-%d %H:%M:%S"), fiscal_year = "FY21") %>% dplyr::select(ou, 
       ou_id, country_name, country_uid, snu1, snu1_id, psnu, psnuid, 
       prioritization, mechanism_code, mechanism_desc, partner_id, 
       partner_desc, funding_agency = agency, fiscal_year, dataelement_id = dataelement, 
       dataelement_name = dataelement.y, indicator = technical_area, 
       numerator_denominator, support_type, hts_modality, categoryoptioncombo_id = categoryoptioncombouid, 
       categoryoptioncombo_name = categoryoptioncombo, age = Age, 
       sex = Sex, key_population = KeyPop, resultstatus_specific = resultstatus, 
       upload_timestamp, disagg_type, resultstatus_inclusive, top_level, 
       target_value = value, indicator_code)
3: createAnalytics(d)
2: unPackDataPack(d)
1: unPackTool("~/datapackr_test_files/for_repack_PSNUxIM copy/Data Pack_Rwanda_20200211_v8_snuxim.xlsx")
```