### PR TITLE
Update packSNUxIM.R

### DIFF
--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -78,7 +78,7 @@ packSNUxIM <- function(d) {
                                        -psnuid, -sheet_name))
           
       # Allow DataPackTarget formula to lookup KP_MAT correctly ####
-        if (cop_year == 2020) {
+        if (d$info$cop_year == 2020) {
           d$data$SNUxIM_combined %<>%  
             dplyr::mutate(
               KeyPop = dplyr::case_when(


### PR DESCRIPTION
There is a lingering local variable reference in PackPSNUxIM, which should instead reference `d$info$cop_year`. 

This prevents processing of the PSNUxIM tab in the app. 

FYI @jacksonsj 

@sam-bao if you are OK with this change, please merge, as its preventing further work on the app. 