### PR TITLE
Adds OU and SNU1 back to analytics table

### DIFF
--- a/R/adornPSNUs.R
+++ b/R/adornPSNUs.R
@@ -14,7 +14,8 @@
 adornPSNUs <- function(d) {
 
   PSNUList <- datapackr::valid_PSNUs %>%
-      dplyr::select(country_name, country_uid, psnu, psnu_uid)
+      dplyr::select(ou, ou_id, country_name, country_uid,
+                    snu1, snu1_id, psnu, psnu_uid)
 
   d$data$analytics %<>% dplyr::left_join(PSNUList, by = c("psnuid" = "psnu_uid"))
 

--- a/R/createAnalytics.R
+++ b/R/createAnalytics.R
@@ -91,8 +91,12 @@ createAnalytics <- function(d,
   # Selects appropriate columns based on COP or OPU tool
   if (d$info$tool == "Data Pack") {
     d$data$analytics %<>%
-      dplyr::select( country_name,
+      dplyr::select( ou,
+                     ou_id,
+                     country_name,
                      country_uid,
+                     snu1,
+                     snu1_id,
                      psnu,
                      psnuid,
                      prioritization,
@@ -122,8 +126,12 @@ createAnalytics <- function(d,
                      indicator_code)
   } else {
     d$data$analytics %<>%
-      dplyr::select( country_name,
+      dplyr::select( ou,
+                     ou_id,
+                     country_name,
                      country_uid,
+                     snu1,
+                     snu1_id,
                      psnu,
                      psnuid,
                      mechanism_code,


### PR DESCRIPTION
@jacksonsj some changes I made due to problems unpacking data packs in version 3.0.7 (https://pepfar.sharepoint.com/:x:/r/sites/PRIMEInformationSystems/Shared%20Documents/COP%2020%20Data%20Pack%20Staging%20Area/Misc/D) are at least part of what is causing problems for visualization.

This PR will add back into `adornPSNUs` and `createAnalytics` the following columns from `validPSNUs`.

As far as I can tell the only place adornPSNUs is called in datapackr is from createAnalytics, and the d$data$analytics is not directly used elsewhere in datapackr. So based on a code review this does not appear to cause any problems. I also ran my testing script which packs and unpacks a COP 20 OPU, packs, unpacks a cop21 data pack and also writes SNUxIM tabs and none of the current code in 4.2.1+this PR is erring out.

I would like to merge this into 4.2.1 where I will continue to review that branch to be pulled into master.