### PR TITLE
unpackSchema exclude FY column when cop_year==2020

### DIFF
--- a/R/unPackSchema.R
+++ b/R/unPackSchema.R
@@ -391,6 +391,8 @@ unPackSchema_datapack <- function(filepath = NULL,
         "\n")
       )
   }
-
+if (cop_year == 2020){
+  schema <- dplyr::select(schema, -FY)
+}
   return(schema)
 }


### PR DESCRIPTION
Unable to pack a COP20 OPU due to presence of FY in schema. This excludes FY if cop_year == "2020"