### PR TITLE
unPackSchema for COP20 exclude the new period column

### DIFF
--- a/R/unPackSchema.R
+++ b/R/unPackSchema.R
@@ -401,7 +401,7 @@ unPackSchema_datapack <- function(filepath = NULL,
       )
   }
   if (cop_year == 2020){
-    schema <- dplyr::select(schema, -FY)
+    schema <- dplyr::select(schema, -FY, -period)
   }
   
   return(schema)


### PR DESCRIPTION
period was added as part of PR267, but isn't applicable for COP20 OPU datapacks

fix for https://jira.pepfar.net/browse/DP-223