### PR TITLE
Ensure correct period handling for TX_CURR_SUBNAT.R

### DIFF
--- a/R/adorn_import_file.R
+++ b/R/adorn_import_file.R
@@ -110,7 +110,12 @@ adorn_import_file <- function(psnu_import_file,
   data %<>%
     dplyr::mutate(
       upload_timestamp = format(Sys.time(),"%Y-%m-%d %H:%M:%S", tz = "UTC"),
-      fiscal_year = as.numeric(stringr::str_replace(period, "Oct|Q4", "")) + 1 ) %>%
+      fiscal_year = suppressWarnings(dplyr::if_else(stringr::str_detect(period, "Oct"),
+                                                    as.numeric(stringr::str_replace(period, "Oct", "")) + 1,
+                                                    as.numeric(stringr::str_replace(period, "Q3", ""))
+                                                    )
+                                     )
+      ) %>%
     dplyr::left_join(
       (map_DataPack_DATIM_DEs_COCs_local %>%
           dplyr::rename(

--- a/R/exportSubnatToDatim.R
+++ b/R/exportSubnatToDatim.R
@@ -19,9 +19,6 @@ exportSubnatToDATIM <- function(d) {
                             "Sex" = "valid_sexes.name",
                             "KeyPop" = "valid_kps.name")) %>%
     dplyr::mutate(
-      period = dplyr::case_when(
-        stringr::str_detect(indicator_code, "\\.R$") ~ paste0(FY-1,"Q4" ),
-        TRUE ~ paste0(FY-1,"Oct" )),
       attributeOptionCombo = datapackr::default_catOptCombo()
     ) %>%
     dplyr::mutate(


### PR DESCRIPTION
The iso period for TX_CURR_SUBNAT.R is 2020Q3 (see: https://github.com/pepfar-datim/datapackr/pull/272/commits/a705d8847f27505eb0c9d07e7cfa7f355aa1239c) so the FY should be 2020 for COP21. The referenced commit was supposed to make these changes the d$datim$subnat_impatt object but there was some code in exportSubnatToDATIM overwriting the intended changes and this also affects d$data$analytics.

