### PR TITLE
Vectorize comparison between deduced countries and home tabcountries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datapackr
 Type: Package
 Title: A Package that Packs and Unpacks all Data Packs
-Version: 4.3.6
-Date: 2021-4-21
+Version: 4.3.7
+Date: 2021-4-22
 Authors@R: c(
     person("Scott", "Jackson", email = "sjackson@baosystems.com",
         role = c("aut", "cre")),

--- a/R/unPackCountryUIDs.R
+++ b/R/unPackCountryUIDs.R
@@ -144,7 +144,8 @@ unPackCountryUIDs <- function(submission_path,
                        dplyr::select(psnu_uid, country_name, country_uid),
                      by = "psnu_uid")
   
-  if (!country_uids %in% unique(PSNUs$country_uid)) {
+  if (!all(purrr::map_lgl(unique(PSNUs$country_uid), 
+                          ~ .x %in% country_uids))) {
     stop("Deduced or provided Country UIDs do no match Country UIDs observed in submission.")
   }
   

--- a/R/unPackDataPack.R
+++ b/R/unPackDataPack.R
@@ -82,7 +82,8 @@ unPackDataPack <- function(d,
     dplyr::pull(country_uid) %>%
     unique()
 
-  if (!d$info$country_uids %in% unique(observed_country_uids)) {
+  if (!all(purrr::map_lgl(observed_country_uids, 
+                         ~ .x %in% d$info$country_uids))) {
     stop("Deduced or provided Country UIDs do no match Country UIDs observed in submission.")
   }
 


### PR DESCRIPTION
When parsing Caribbean region data pack was receiving this error

```
Error in unPackDataPack(d, d2_session = d2_session) : 
  Deduced or provided Country UIDs do no match Country UIDs observed in submission.
```

also these warnings:

```
In addition: Warning messages:
1: In if (!country_uids %in% unique(PSNUs$country_uid)) { :
  the condition has length > 1 and only the first element will be used
2: In if (!d$info$country_uids %in% unique(observed_country_uids)) { :
  the condition has length > 1 and only the first element will be used
```

This PR resolves the main issue which was vectorizing the `%in%` comparison. Also switched the comparison to check if all countries implied by the target data match the countries listed in the home tab rather than the reverse. It seems possible that there would not be any target data for some countries listed in the home tab as regional countries may fill in the datapck in stages.
