### PR TITLE
Check analytics tests sam

### DIFF
--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -182,7 +182,7 @@ test_that(" Test retention < 98% expect message", {
 test_that(" Test retention > 100% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~TX_CURR.T,~TX_CURR.T_1,~TX_NEW.T,
-    "a",   1,         "<1",  "F",  NA,                    100,        10, 10,
+    "a",   1,         "<1",  "F",  NA,                    101,        10, 90,
     "b",  2,          "<1", "M", NA,                         0,         0, 0
   )
   
@@ -190,7 +190,7 @@ test_that(" Test retention > 100% expect message", {
   testthat::expect_equal(class(foo),"list")
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
-  expect_equal(foo$test_results$TX.Retention.T,5,tolerance=1e-3)
+  expect_equal(foo$test_results$TX.Retention.T,1.01,tolerance=1e-3)
   
 } )
 

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -145,8 +145,8 @@ test_that("TB Known Pos ratio > 75% expect message" , {
 test_that("TB Known Pos ratio < 75% expect message expect null" , {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~TB_STAT.N.New.Pos.T,~TB_STAT.N.KnownPos.T,~TB_STAT.N.New.Neg.T,
-    "a",   1,         "<1",  "M",  NA,                         10,        10, 10,
-    "b",  2,          "<1", "M", NA,                         0,         0, 0
+    "a",   1,         "<1",  "M",  NA,                         25,        150, 25,
+    "b",  2,          "<1", "M", NA,                         0,         0, 0,
   )
   
   expect_null(analyze_tbknownpos(data))

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -183,7 +183,7 @@ test_that(" Test retention > 100% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~TX_CURR.T,~TX_CURR.T_1,~TX_NEW.T,
     "a",   1,         "<1",  "F",  NA,                    101,        10, 90,
-    "b",  2,          "<1", "M", NA,                         0,         0, 0
+    "b",  2,          "<1", "M", NA,                      100,        10, 90
   )
   
   foo<-analyze_retention(data)

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -3,7 +3,8 @@ context("test-check-analytics")
 test_that("PMTCT_EID coverage by 2 months old < 90% expect message" , {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~PMTCT_EID.N.2.T,~PMTCT_EID.N.12.T,
-    "a",   1,         "<1",  "F",  NA,                         1,        100
+    "a",   1,         "<1",  "F",  NA,                         1,        100,
+    "b",   1,         "<1",  "F",  NA,                         90,        10
   )
   
   foo<-analyze_eid_2mo(data)

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -167,7 +167,7 @@ test_that("PMTCT Known Pos/PMTCT Total all zeros expect null" , {
 test_that(" Test retention < 98% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~TX_CURR.T,~TX_CURR.T_1,~TX_NEW.T,
-    "a",   1,         "<1",  "F",  NA,                    10,        10, 10,
+    "a",   1,         "<1",  "F",  NA,                    97,        97, 3,
     "b",  2,          "<1", "M", NA,                         0,         0, 0
   )
   
@@ -175,7 +175,7 @@ test_that(" Test retention < 98% expect message", {
   testthat::expect_equal(class(foo),"list")
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
-  expect_equal(foo$test_results$TX.Retention.T,0.5,tolerance=1e-3)
+  expect_equal(foo$test_results$TX.Retention.T,0.97,tolerance=1e-3)
   
 } )
 

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -219,30 +219,30 @@ test_that(" Test retention all zeros expect NULL", {
 test_that(" Test linkage < 95% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    100,          10,                                10,                 0,               0,
-    "b",  2,          "25-49", "M",  NA,                         0,           0,                                0,                 0,               0
+    "a",   1,         "25-49",  "F",  NA,                    95,          5,                                94,                 0,               0,
+    "b",  2,          "25-49", "M",  NA,                         95,           5,                                95,                 0,               0
   )
   
   foo<-analyze_linkage(data)
   testthat::expect_equal(class(foo),"list")
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
-  expect_equal(foo$test_results$HTS_TST.Linkage.T,0.0909,tolerance=1e-3)
+  expect_equal(foo$test_results$HTS_TST.Linkage.T,0.94,tolerance=1e-3)
   
 } )
 
 test_that(" Test linkage > 100% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    1,          1,                                10,                 0,               0,
-    "b",  2,          "25-49", "M",  NA,                         0,           0,                                0,                 0,               0
+    "a",   1,         "25-49",  "F",  NA,                    50,          50,                                100,                 0,               0,
+    "b",  2,          "25-49", "M",  NA,                         50,           50,                              101,                 0,               0
   )
   
   foo<-analyze_linkage(data)
   testthat::expect_equal(class(foo),"list")
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
-  expect_equal(foo$test_results$HTS_TST.Linkage.T,5,tolerance=1e-3)
+  expect_equal(foo$test_results$HTS_TST.Linkage.T,1.01,tolerance=1e-3)
   
 } )
 

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -129,7 +129,7 @@ test_that("PMTCT Known Pos/PMTCT Total all zeros expect null" , {
 test_that("TB Known Pos ratio > 75% expect message" , {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~TB_STAT.N.New.Pos.T,~TB_STAT.N.KnownPos.T,~TB_STAT.N.New.Neg.T,
-    "a",   1,         "<1",  "M",  NA,                         10,        100, 10,
+    "a",   1,         "<1",  "M",  NA,                         25,        151, 25,
     "b",  2,          "<1", "M", NA,                         0,         0, 0
   )
   
@@ -137,7 +137,7 @@ test_that("TB Known Pos ratio > 75% expect message" , {
   testthat::expect_equal(class(foo),"list")
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
-  expect_equal(foo$test_results$knownpos_ratio,0.833,tolerance=1e-3)
+  expect_equal(foo$test_results$knownpos_ratio,0.751,tolerance=1e-3)
   
   
 } )

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -107,7 +107,8 @@ test_that("PMTCT Known Pos/PMTCT Total <  0.75 expect null" , {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~PMTCT_STAT.N.New.Pos.T,~PMTCT_STAT.N.KnownPos.T,~PMTCT_STAT.N.New.Neg.T,
     "a",   1,         "<1",  "M",  NA,                         10,        10, 10,
-    "b",  2,          "<1", "M", NA,                         0,         0, 0
+    "b",  2,          "<1", "M", NA,                         0,         0, 0,
+    "c",  3,          "<1", "M", NA,                         25,         150, 25
   )
   
   expect_null(analyze_pmtctknownpos(data))

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -219,8 +219,8 @@ test_that(" Test retention all zeros expect NULL", {
 test_that(" Test linkage < 95% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    95,          5,                                94,                 0,               0,
-    "b",  2,          "25-49", "M",  NA,                         95,           5,                                95,                 0,               0
+    "a",   1,         "25-49",  "F",  NA,                    95,          5,                                94,                 100,               94,
+    "b",  2,          "25-49", "M",  NA,                         95,           5,                                95,                 100,               95,
   )
   
   foo<-analyze_linkage(data)
@@ -228,14 +228,14 @@ test_that(" Test linkage < 95% expect message", {
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.Linkage.T,0.94,tolerance=1e-3)
-  
+  expect_equal(foo$test_results$HTS_TST.KP.Linkage.T,0.94,tolerance=1e-3)
 } )
 
 test_that(" Test linkage > 100% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    50,          50,                                100,                 0,               0,
-    "b",  2,          "25-49", "M",  NA,                         50,           50,                              101,                 0,               0
+    "a",   1,         "25-49",  "F",  NA,                    50,          50,                                100,                 100,               100,
+    "b",  2,          "25-49", "M",  NA,                         50,           50,                              101,                 100,               101
   )
   
   foo<-analyze_linkage(data)
@@ -243,13 +243,13 @@ test_that(" Test linkage > 100% expect message", {
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.Linkage.T,1.01,tolerance=1e-3)
-  
+  expect_equal(foo$test_results$HTS_TST.KP.Linkage.T,1.01,tolerance=1e-3)
 } )
 
 test_that(" Test linkage = 98% expect NULL", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    20,          20,                                39,                 0,               0,
+    "a",   1,         "25-49",  "F",  NA,                    20,          20,                                39,                 40,               39,
     "b",  2,          "25-49", "M",  NA,                         0,           0,                                0,                 0,               0
   )
   

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -304,3 +304,17 @@ test_that(" Test linkage all zeros expect NULL", {
   expect_null(analyze_linkage(data))
   
 } )
+
+test_that(" Test linkage with age <1", {
+  data<-tribble(
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
+    "a",   1,         "<01", "M",  NA,                    50,          50,                                101,                 100,               100,
+    "b",  2,          NA, NA,  "PWID",                         0,           0,                             0,                 100,               101
+  )
+  
+  foo<-analyze_linkage(data)
+  testthat::expect_equal(class(foo),"list")
+  testthat::expect_setequal(names(foo),c("test_results","msg"))
+  testthat::expect_equal(NROW(foo$test_results),1)
+  expect_equal(foo$test_results$HTS_TST.KP.Linkage.T,1.01,tolerance=1e-3)
+} )

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -219,8 +219,8 @@ test_that(" Test retention all zeros expect NULL", {
 test_that(" Test linkage < 95% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    95,          5,                                94,                 100,               94,
-    "b",  2,          "25-49", "M",  NA,                         95,           5,                                95,                 100,               95,
+    "a",   1,         "25-49",  "F",  NA,                    95,          5,                                94,                 0,               0,
+    "b",  2,          "25-49", "M",  NA,                         95,           5,                                95,                 0,               0
   )
   
   foo<-analyze_linkage(data)
@@ -228,14 +228,27 @@ test_that(" Test linkage < 95% expect message", {
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.Linkage.T,0.94,tolerance=1e-3)
+} )
+
+test_that(" Test KP linkage < 95% expect message", {
+  data<-tribble(
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
+    "a",   1,         NA,  NA,  "PWID",                    0,          0,                                0,                 100,               94,
+    "b",  2,          NA, NA, "PWID",                         0,           0,                                0,                 100,               95
+  )
+  
+  foo<-analyze_linkage(data)
+  testthat::expect_equal(class(foo),"list")
+  testthat::expect_setequal(names(foo),c("test_results","msg"))
+  testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.KP.Linkage.T,0.94,tolerance=1e-3)
 } )
 
 test_that(" Test linkage > 100% expect message", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    50,          50,                                100,                 100,               100,
-    "b",  2,          "25-49", "M",  NA,                         50,           50,                              101,                 100,               101
+    "a",   1,         "25-49",  "F",  NA,                    50,          50,                                100,                 0,               0,
+    "b",  2,          "25-49", "M",  NA,                         50,           50,                              101,                 0,               0
   )
   
   foo<-analyze_linkage(data)
@@ -243,14 +256,38 @@ test_that(" Test linkage > 100% expect message", {
   testthat::expect_setequal(names(foo),c("test_results","msg"))
   testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.Linkage.T,1.01,tolerance=1e-3)
+} )
+
+test_that(" Test KP linkage > 100% expect message", {
+  data<-tribble(
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
+    "a",   1,         NA, NA,  "PWID",                    0,          0,                                0,                 100,               100,
+    "b",  2,          NA, NA,  "PWID",                         0,           0,                             0,                 100,               101
+  )
+  
+  foo<-analyze_linkage(data)
+  testthat::expect_equal(class(foo),"list")
+  testthat::expect_setequal(names(foo),c("test_results","msg"))
+  testthat::expect_equal(NROW(foo$test_results),1)
   expect_equal(foo$test_results$HTS_TST.KP.Linkage.T,1.01,tolerance=1e-3)
 } )
 
 test_that(" Test linkage = 98% expect NULL", {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
-    "a",   1,         "25-49",  "F",  NA,                    20,          20,                                39,                 40,               39,
+    "a",   1,         "25-49",  "F",  NA,                    20,          20,                                39,                 0,               0,
     "b",  2,          "25-49", "M",  NA,                         0,           0,                                0,                 0,               0
+  )
+  
+  expect_null(analyze_linkage(data))
+  
+} )
+
+test_that(" Test KP linkage = 98% expect NULL", {
+  data<-tribble(
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~HTS_INDEX_COM.New.Pos.T,~HTS_INDEX_FAC.New.Pos.T,~TX_NEW.T,~HTS_TST.KP.Pos.T,~TX_NEW.KP.T,
+    "a",   1,         NA, NA,  "PWID",                    0,          0,                                0,                 100,               98,
+    "b",  2,          NA, NA,  "PWID",                         0,           0,                             0,                 0,               0
   )
   
   expect_null(analyze_linkage(data))

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -76,6 +76,17 @@ test_that("VMMC_CIRC Indeterminate Rate all zeros expect NULL" , {
   
 } )
 
+test_that("VMMC_CIRC Indeterminate Rate all keypop not NA expect NULL" , {
+  data<-tribble(
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~VMMC_CIRC.Pos.T,~VMMC_CIRC.Neg.T,~VMMC_CIRC.Unk.T,
+    "a",   1,         "<1",  "M",  "PWID",                         0,        0, 1
+  )
+  
+  foo<-analyze_vmmc_indeterminate(data)
+  expect_null(foo)
+  
+} )
+
 test_that("PMTCT Known Pos/PMTCT Total >  0.75 expect message" , {
   data<-tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population,~PMTCT_STAT.N.New.Pos.T,~PMTCT_STAT.N.KnownPos.T,~PMTCT_STAT.N.New.Neg.T,


### PR DESCRIPTION
Minor changes to check analytics unit tests to place test data closer to or on boundaries of the analytics checks. E.g. if a warning is meant to be thrown for linkage > 100%, I changed the test data to equate to 100% and 101%.

Added Linkage tests for the KP data elements.

Added linkage test for filtering out age <01