### PR TITLE
DP-347: Remove Purrr dependency in checkComments

### DIFF
--- a/R/checkComments.R
+++ b/R/checkComments.R
@@ -18,6 +18,7 @@ checkComments <- function(d) {
       lapply(wb$comments, function(x) is.null(x["style"]))
       )
     )
+  
   if (d$info$has_comments_issue) {
     warning_msg <-
       paste0(

--- a/R/checkComments.R
+++ b/R/checkComments.R
@@ -14,12 +14,12 @@ checkComments <- function(d) {
   wb <- openxlsx::loadWorkbook(d$keychain$submission_path)
 
   d$info$has_comments_issue <-
-    purrr::map(wb$comments,
-             function(y) purrr::map(y,
-                                    function(x) is.null(purrr::pluck(x, "style")))) %>%
-    unlist() %>%
-    any()
-
+    any(
+      unlist(
+        lapply(wb$comments, function(x) is.null(x["style"]))
+      )
+    )
+  
   if (d$info$has_comments_issue) {
     warning_msg <-
       paste0(

--- a/R/checkComments.R
+++ b/R/checkComments.R
@@ -13,13 +13,11 @@ checkComments <- function(d) {
 
   wb <- openxlsx::loadWorkbook(d$keychain$submission_path)
 
-  d$info$has_comments_issue <-
-    any(
-      unlist(
-        lapply(wb$comments, function(x) is.null(x["style"]))
+  d$info$has_comments_issue <- any(
+    unlist(
+      lapply(wb$comments, function(x) is.null(x["style"]))
       )
     )
-  
   if (d$info$has_comments_issue) {
     warning_msg <-
       paste0(

--- a/tests/testthat/test-checkComments.R
+++ b/tests/testthat/test-checkComments.R
@@ -1,0 +1,16 @@
+context("test-checkComments")
+
+#test passing of template
+test_that("Can pass a COP21 DP Template", {
+  d  <-   datapackr:::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
+                                         tool = "Data Pack",
+                                         country_uids = NULL,
+                                         cop_year = NULL)
+  expect_silent(foo <- checkComments(d))
+  #should expect no issues so FALSE
+  expect_false(foo$info$has_comments_issue)
+})
+
+
+
+


### PR DESCRIPTION
Changed purrr mapping to base R lapply for less code and less library use. Added unit test test-checkComments.R.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Refactoring so no issue in this case

## Summary of Proposed Changes
- looking to lessen dependencies on libraries so working through modules to refactor and transition to base R when possible.

## Affected Process Elements
- [ ] Data Pack generation
- [ ] Data Pack model
- [ ] Data Pack self-service app
- [x ] Data Pack processing
- [ ] Site Tool model/distribution
- [ ] Site Tool generation (from Data Pack)
- [ ] Site Tool generation (from DATIM - for OPUs)
- [ ] Site Tool self-service app
- [ ] Site Tool to Data Pack comparison self-service app
- [ ] Site Tool to DATIM comparison self-service app
- [ ] Site Tool processing
- [ ] Site Tool import

## Types of changes

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ x] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

## Related Issues
- Resolves [DP-347](https://jira.pepfar.net/browse/DP-347)

## Testing Approach

- created unit test test-checkComments.R and test passed locally.

## Final Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
