### PR TITLE
DP-529: Cleans up common variables in `data-raw` files

### DIFF
--- a/data-raw/COP20OPU_Data_Pack_generation_script.R
+++ b/data-raw/COP20OPU_Data_Pack_generation_script.R
@@ -1,9 +1,10 @@
 library(datapackr)
-library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 20/3) Testing & Deployment/COP20 OPUs/Test Packs"
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP20 OPUs/")
 
 batch <- tibble::tribble(
   ~datapack_name, ~country_uids,

--- a/data-raw/COP20OPU_Data_Pack_processing_script.R
+++ b/data-raw/COP20OPU_Data_Pack_processing_script.R
@@ -3,7 +3,7 @@
 secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
 datimutils::loginToDATIM(secrets)
 
-output_folder <- Sys.getenv("OUTPUT_FOLDER")
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP20 OPUs/")
 model_data_path <- Sys.getenv("MODEL_DATA_PATH")
 snuxim_model_data_path <- Sys.getenv("SNUXIM_MODEL_DATA_PATH")
 

--- a/data-raw/COP20OPU_Data_Pack_processing_script.R
+++ b/data-raw/COP20OPU_Data_Pack_processing_script.R
@@ -1,12 +1,12 @@
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-# snuxim_model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 20/3) Testing & Deployment/PSNUxIM_20200207.rds"
-# output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 20/3) Testing & Deployment"
-# model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 20/3) Testing & Deployment/model_data_pack_input_20_20200220_1_flat.rds"
+output_folder <- Sys.getenv("OUTPUT_FOLDER")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
+snuxim_model_data_path <- Sys.getenv("SNUXIM_MODEL_DATA_PATH")
 
 d <- unPackTool(tool = "OPU Data Pack")
 
-d <- checkAnalytics(d,
-                   model_data_path)
-
+d <- checkAnalytics(d, model_data_path)

--- a/data-raw/COP20OPU_Data_Pack_validation_script.R
+++ b/data-raw/COP20OPU_Data_Pack_validation_script.R
@@ -2,7 +2,9 @@ library(datapackr)
 library(datimutils)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 d2_session <- d2_default_session
 
@@ -144,5 +146,3 @@ openxlsx::writeData(wb = flatpack_wb,
                     x = modalitySummaryTable(d$data$analytics))
 
 openxlsx::saveWorkbook(flatpack_wb, file = flatpack_filename, overwrite = TRUE)
-
-

--- a/data-raw/COP21OPU_Data_Pack_generation_script.R
+++ b/data-raw/COP21OPU_Data_Pack_generation_script.R
@@ -1,9 +1,11 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/COP21 OPUs"
+output_folder <- Sys.getenv("OUTPUT_FOLDER")
 
 # batch <- tibble::tribble(
 #   ~datapack_name, ~country_uids,

--- a/data-raw/COP21OPU_Data_Pack_generation_script.R
+++ b/data-raw/COP21OPU_Data_Pack_generation_script.R
@@ -5,7 +5,7 @@ library(magrittr)
 secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
 datimutils::loginToDATIM(secrets)
 
-output_folder <- Sys.getenv("OUTPUT_FOLDER")
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP21 OPUs/")
 
 # batch <- tibble::tribble(
 #   ~datapack_name, ~country_uids,

--- a/data-raw/COP21OPU_Data_Pack_processing_script.R
+++ b/data-raw/COP21OPU_Data_Pack_processing_script.R
@@ -1,11 +1,13 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-snuxim_model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/Model Data/PSNUxIM_20210201_1.rds"
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/COP21 OPUs"
-model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/Model Data/model_data_pack_input_21_20210407_1_flat.rds"
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP21 OPUs/")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
+snuxim_model_data_path <- Sys.getenv("SNUXIM_MODEL_DATA_PATH")
 
 # Unpack Submitted Data Pack ####
 d <- unPackTool(tool = "OPU Data Pack", cop_year = 2021)
@@ -14,13 +16,6 @@ d <- unPackTool(tool = "OPU Data Pack", cop_year = 2021)
 #                    model_data_path)
 
 # d <- writePSNUxIM(d, snuxim_model_data_path, output_folder)
-
-
-
-
-
-
-
 
 # Export DATIM import files ####
   exportPackr(data = d$datim$MER,

--- a/data-raw/COP21_Data_Pack_generation_script.R
+++ b/data-raw/COP21_Data_Pack_generation_script.R
@@ -1,11 +1,12 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/Mock Data Pack"
-
-model_data_path <- file.choose()
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "Mock Data Pack/")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
 
 model_data <- readRDS(model_data_path)
 

--- a/data-raw/COP21_Data_Pack_processing_script.R
+++ b/data-raw/COP21_Data_Pack_processing_script.R
@@ -1,11 +1,13 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-snuxim_model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/Model Data/PSNUxIM_20210201_1.rds"
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/COP21 OPUs"
-model_data_path <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment/Model Data/model_data_pack_input_21_20210407_1_flat.rds"
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP21 OPUs/")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
+snuxim_model_data_path <- Sys.getenv("SNUXIM_MODEL_DATA_PATH")
 
 # Unpack Submitted Data Pack ####
 d <- unPackTool(cop_year = 2021)

--- a/data-raw/COP22_Data_Pack_generation_script.R
+++ b/data-raw/COP22_Data_Pack_generation_script.R
@@ -1,12 +1,12 @@
 library(datapackr)
 library(magrittr)
 
-datapackr::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 22/3) Testing & Deployment/Beta Packs"
-
-model_data_path <- file.choose()
-
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "Beta Packs/")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
 model_data <- readRDS(model_data_path)
 
 #Beta Packs ####

--- a/data-raw/COP22_Data_Pack_processing_script.R
+++ b/data-raw/COP22_Data_Pack_processing_script.R
@@ -1,15 +1,17 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
+
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "COP22 Data Packs/")
+model_data_path <- Sys.getenv("MODEL_DATA_PATH")
+snuxim_model_data_path <- Sys.getenv("SNUXIM_MODEL_DATA_PATH")
 
 # Unpack Submitted Data Pack ####
 d <- unPackTool(cop_year = 2022)
 
-#model_data_path <- file.choose()
-# d <- checkAnalytics(d,
-#                    model_data_path)
+# d <- checkAnalytics(d, model_data_path)
 
-snuxim_model_data_path <- file.choose()
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 22/3) Testing & Deployment/Beta Packs"
 d <- writePSNUxIM(d, snuxim_model_data_path, output_folder)

--- a/data-raw/Export_Data_Entry_Forms.R
+++ b/data-raw/Export_Data_Entry_Forms.R
@@ -2,8 +2,9 @@
 # categoryOptionCombo pairs
 
 # Method using datimutils ####
-secrets <- "~/.secrets/cop-test.json"
-datapackr::loginToDATIM(secrets)
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "cop-test.json")
+datimutils::loginToDATIM(secrets)
 entryform_id = "eeZpSGQu8hx"
 data <- datimutils::getMetadata(end_point = "dataEntryForms",
                                 paste0("id:eq:", entryform_id),

--- a/data-raw/GetDataForGlobalFund.R
+++ b/data-raw/GetDataForGlobalFund.R
@@ -5,9 +5,11 @@ library(lubridate)
 require(datapackcommons)
 require(datapackr)
 
-datimutils::loginToDATIM("/users/sam/.secrets/datim.json")
-base_url = getOption("baseurl")
-country_details <- datapackcommons::GetCountryLevels(base_url)
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
+
+country_details <- datapackcommons::GetCountryLevels()
 uids <- country_details$id
 names <- country_details$country_name
 

--- a/data-raw/checkTX_CURR.R
+++ b/data-raw/checkTX_CURR.R
@@ -16,7 +16,7 @@ library(stringr)
 library(datapackr)
 
 # Point to DATIM login secrets ####
-secrets <- "/Users/scott/.secrets/datim.json"
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
 
 datimutils::loginToDATIM(secrets)
 

--- a/data-raw/extract-spectrum-data.R
+++ b/data-raw/extract-spectrum-data.R
@@ -1,6 +1,7 @@
 library(magrittr)
 library(datapackr)
 
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0("Spectrum Examples/")
 dp_folder <- "/Users/scott/Downloads/BetaPack COP21 DPs"
 
 dp_filenames <- list.files(dp_folder)
@@ -46,11 +47,10 @@ for (filepath in dp_filepaths) {
   
 }
 
-saveRDS(spectrum_extracts, "/Volumes/GoogleDrive/My Drive/PEPFAR/COP Targets/COP 22/2) Development/Spectrum Examples/SpectrumExtracts.rds")
+saveRDS(spectrum_extracts, paste0(output_folder, "SpectrumExtracts.rds"))
 
 
 # Export ####
-output_path <- "/Volumes/GoogleDrive/My Drive/PEPFAR/COP Targets/COP 22/2) Development/Spectrum Examples/"
 
 for (i in 1:length(spectrum_extracts)) {
   country <- spectrum_extracts[[i]]$country_name

--- a/data-raw/generate_play_spectrum_output.R
+++ b/data-raw/generate_play_spectrum_output.R
@@ -1,9 +1,11 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
-output_folder <- "/Users/scott/Google Drive/PEPFAR/COP Targets/COP 21/3) Testing & Deployment"
+output_folder <- Sys.getenv("OUTPUT_FOLDER")
 
 batch <- tibble::tribble(
   ~datapack_name, ~country_uids,

--- a/data-raw/produceConfigFile.R
+++ b/data-raw/produceConfigFile.R
@@ -262,7 +262,8 @@ getPeriodInfo <- function(FY = NA,
 
 
 # Procedural logic to generate the actual schemas
-    secrets <- "/Users/scott/.secrets/datim.json"
+  ## Point to DATIM login secrets ####
+    secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
     datimutils::loginToDATIM(secrets)
 
   ## Config File ####

--- a/data-raw/test_datasets.R
+++ b/data-raw/test_datasets.R
@@ -245,9 +245,12 @@ packCOP22TestDataset <- function(country_uids,
 library(magrittr)
 library(datapackr)
 
-datapackr::loginToDATIM("~/.secrets/cop-test.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "cop-test.json")
+datimutils::loginToDATIM(secrets)
+
+output_folder <- Sys.getenv("OUTPUT_FOLDER")
 cop_year = 2022
-output_path <- "/Volumes/GoogleDrive/My Drive/PEPFAR/COP Targets/COP 22/3) Testing & Deployment/Test Data/"
 
 # Scenario A: Vanilla case ####
 datapack_names <- c("Cameroon")
@@ -337,7 +340,7 @@ scenario_names <- c("scenario_a", "scenario_b", "scenario_c", "scenario_e",
  
 for (i in 1:length(scenarios)) {
   output_file_name <- 
-    paste0(output_path, "Data Pack_", scenario_names[i], "_",
+    paste0(output_folder, "Data Pack_", scenario_names[i], "_",
            format(Sys.time(), "%Y%m%d%H%M%S"), ".csv")
   
   readr::write_csv(scenarios[[i]], output_file_name)

--- a/data-raw/test_datasets.R
+++ b/data-raw/test_datasets.R
@@ -249,7 +249,7 @@ library(datapackr)
 secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "cop-test.json")
 datimutils::loginToDATIM(secrets)
 
-output_folder <- Sys.getenv("OUTPUT_FOLDER")
+output_folder <- Sys.getenv("OUTPUT_FOLDER") %>% paste0(., "Test Data/")
 cop_year = 2022
 
 # Scenario A: Vanilla case ####

--- a/data-raw/update_cached_PSNUs.R
+++ b/data-raw/update_cached_PSNUs.R
@@ -2,8 +2,8 @@
 library(magrittr)
 library(datapackr)
 
-secrets <- "~/.secrets/datim.json"
-
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
 datimutils::loginToDATIM(secrets)
 
 # NOTE: Full documentation can be found in data.R

--- a/data-raw/update_cached_de_coc_co_map.R
+++ b/data-raw/update_cached_de_coc_co_map.R
@@ -2,7 +2,9 @@
 # metadata, then combines this with the Data Pack schema to create a full map between
 # Data Packs and DATIM for the purpose of generating import and analytics tables.
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 cop_year = getCurrentCOPYear()
 

--- a/data-raw/update_cached_map_datapack_cogs.R
+++ b/data-raw/update_cached_map_datapack_cogs.R
@@ -2,8 +2,8 @@
 library(magrittr)
 library(datapackr)
 
-secrets <- "~/.secrets/cop-test.json"
-
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "cop-test.json")
 datimutils::loginToDATIM(secrets)
 
 # Processing

--- a/data-raw/update_cached_valid_COs.R
+++ b/data-raw/update_cached_valid_COs.R
@@ -1,7 +1,7 @@
 ## Save Valid COs ####
 
-secrets <- "/Users/scott/.secrets/test-mer2.json"
-
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "test-mer2.json")
 datimutils::loginToDATIM(secrets)
 
 valid_category_options <- getValidCategoryOptions(cop_year = getCurrentCOPYear())

--- a/data-raw/update_cop20OPU_datapack_schema.R
+++ b/data-raw/update_cop20OPU_datapack_schema.R
@@ -1,7 +1,9 @@
 ## If you've made any edits to the Excel template, rebuild package first to
 ## capture these, then run the below.
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 datapack_template_filepath <- system.file("extdata",
                                           "COP20_OPU_Data_Pack_Template.xlsx",

--- a/data-raw/update_cop20_datapack_template.R
+++ b/data-raw/update_cop20_datapack_template.R
@@ -1,8 +1,8 @@
 ## If you've made any edits to the Excel template, rebuild package first to
 ## capture these, then run the below.
 
-secrets <- "/Users/scott/.secrets/triage.json"
-
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "triage.json")
 datimutils::loginToDATIM(secrets)
 
 datapack_template_filepath <- system.file("extdata",

--- a/data-raw/update_cop21OPU_datapack_schema.R
+++ b/data-raw/update_cop21OPU_datapack_schema.R
@@ -1,7 +1,9 @@
 ## If you've made any edits to the Excel template, rebuild package first to
 ## capture these, then run the below.
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 datapack_template_filepath <- system.file("extdata",
                                           "COP21_OPU_Data_Pack_Template.xlsx",

--- a/data-raw/update_cop21_datapack_schema.R
+++ b/data-raw/update_cop21_datapack_schema.R
@@ -1,7 +1,9 @@
 ## If you've made any edits to the Excel template, rebuild package first to
 ## capture these, then run the below.
 
-datimutils::loginToDATIM("/Users/scott/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 datapack_template_filepath <- system.file("extdata",
                                           "COP21_Data_Pack_Template.xlsx",

--- a/data-raw/update_cop22_datapack_schema.R
+++ b/data-raw/update_cop22_datapack_schema.R
@@ -4,7 +4,9 @@
 library(datapackr)
 library(magrittr)
 
-datimutils::loginToDATIM("/Users/scott/.secrets/datim.json")
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 
 datapack_template_filepath <- system.file("extdata",
                                           "COP22_Data_Pack_Template.xlsx",

--- a/data-raw/update_cop22_de_coc_co_map.R
+++ b/data-raw/update_cop22_de_coc_co_map.R
@@ -2,8 +2,9 @@
 # metadata, then combines this with the Data Pack schema to create a full map between
 # Data Packs and DATIM for the purpose of generating import and analytics tables.
 
-datimutils::loginToDATIM("~/.secrets/datim.json")
-
+# Point to DATIM login secrets ####
+secrets <- Sys.getenv("SECRETS_FOLDER") %>% paste0(., "datim.json")
+datimutils::loginToDATIM(secrets)
 cop_year = 2022
 
 # Pull code lists ####


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Moves the following variables into the .Rprofile file as environment variables:
* `SECRETS_FOLDER`
* `OUTPUT_FOLDER`
* `MODEL_DATA_PATH`
* `SNUXIM_MODEL_DATA_PATH`

Adds code to add extensions to secrets folder and output folder where appropriate.

### Related Issues
- DP-529

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
