### PR TITLE
Openxlsx Formatting Fix

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -113,7 +113,7 @@ swapColumns <- function(to, from) {
               ~ magrittr::use_series(from, x), x = as.name(col)
             )), col)
           to <- to %>%
-            dplyr::mutate_(.dots = dots)
+            dplyr::mutate(.dots = dots)
         } else {
           next
         }

--- a/renv.lock
+++ b/renv.lock
@@ -664,10 +664,12 @@
     },
     "openxlsx": {
       "Package": "openxlsx",
-      "Version": "4.2.4",
-      "Source": "Repository",
+      "Version": "4.2.3",
+      "Source": "URL",
       "Repository": "CRAN",
-      "Hash": "f1b1ca1254ccb485dccc9c0dc65a2c36"
+      "RemoteType": "url",
+      "RemoteUrl": "https://cran.r-project.org/src/contrib/Archive/openxlsx/openxlsx_4.2.3.tar.gz",
+      "Hash": "5d70bb3a67baaa87f9ed7eb74eed1886"
     },
     "pillar": {
       "Package": "pillar",


### PR DESCRIPTION
Reverted back to openxlsx 4.2.3 in order to preserve datapack formatting when utilizing `saveWorkbook`. 

## Developer: Fausto Lopez

### Summary of Proposed Changes
- Resolves bug associated formatting of excel workbooks when saved using the `saveWorkbook` function.
- unrelated: fixed deprecation warning in `swapColumns` function in `utilities` from `mutate_(` to `mutate()`

### Related Issues
- DP-543
