### PR TITLE
Removes unnecessary use of `:::`

### DIFF
--- a/tests/testthat/test-checkComments.R
+++ b/tests/testthat/test-checkComments.R
@@ -2,7 +2,7 @@ context("test-checkComments")
 
 #test passing of template
 test_that("Can pass a COP21 DP Template", {
-  d  <-   datapackr:::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
+  d  <-   datapackr::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
                                          tool = "Data Pack",
                                          country_uids = NULL,
                                          cop_year = NULL)

--- a/tests/testthat/test-checkStructure.R
+++ b/tests/testthat/test-checkStructure.R
@@ -2,7 +2,7 @@ context("test-checkStructure")
 
 
 test_that("Can pass a COP21 DP Template", {
-  d  <-   datapackr:::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
+  d  <-   datapackr::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
                                       tool = "Data Pack",
                                       country_uids = NULL,
                                       cop_year = NULL)
@@ -18,7 +18,7 @@ test_that("Can warn on missing COP21 DP sheet", {
   wb <- openxlsx::loadWorkbook(template_copy)
   openxlsx::removeWorksheet(wb, "PMTCT")
   openxlsx::saveWorkbook(wb, file = template_copy, overwrite = TRUE)
-  d <- datapackr:::createKeychainInfo(submission_path = template_copy,
+  d <- datapackr::createKeychainInfo(submission_path = template_copy,
                                       tool = "Data Pack",
                                       country_uids = NULL,
                                       cop_year = NULL)
@@ -28,7 +28,7 @@ test_that("Can warn on missing COP21 DP sheet", {
 })
 
 test_that("Can pass a COP20 OPU Template", {
-  expect_warning(d <- datapackr:::createKeychainInfo(submission_path = test_sheet("COP20_OPU_Data_Pack_Template.xlsx"),
+  expect_warning(d <- datapackr::createKeychainInfo(submission_path = test_sheet("COP20_OPU_Data_Pack_Template.xlsx"),
                                       tool = "OPU Data Pack Template",
                                       country_uids = NULL,
                                       cop_year = NULL))

--- a/tests/testthat/test-create-analytics.R
+++ b/tests/testthat/test-create-analytics.R
@@ -5,7 +5,7 @@ with_mock_api({
   test_that("We can create analytics", {
 
     d <-
-      datapackr:::createKeychainInfo(
+      datapackr::createKeychainInfo(
         submission_path = test_sheet("COP21_DP_random_with_psnuxim.xlsx"),
         tool = "Data Pack",
         country_uids = NULL,

--- a/tests/testthat/test-handshake.R
+++ b/tests/testthat/test-handshake.R
@@ -2,14 +2,14 @@ context("test-handshake")
 
 
 test_that("Can handshake template", {
-  d <- datapackr:::handshakeFile(path = test_sheet("COP20_Data_Pack_Template_vFINAL.xlsx"),
+  d <- datapackr::handshakeFile(path = test_sheet("COP20_Data_Pack_Template_vFINAL.xlsx"),
                      tool = "Data Pack Template")
   expect_true(file.exists(d))
 })
 
 test_that("Can error on bad type", {
 
-  expect_error(datapackr:::handshakeFile(test_sheet("COP20_Data_Pack_Template_vFINAL.xlsx"),
+  expect_error(datapackr::handshakeFile(test_sheet("COP20_Data_Pack_Template_vFINAL.xlsx"),
                    "Foo Template"),
                    "Please specify correct file type: Data Pack, Data Pack Template, OPU Data Pack Template.")
 
@@ -17,7 +17,7 @@ test_that("Can error on bad type", {
 
 test_that("Can error on bad file location", {
 
-  expect_error(datapackr:::handshakeFile("/home/littlebobbytables/DataPack.xlsx",
+  expect_error(datapackr::handshakeFile("/home/littlebobbytables/DataPack.xlsx",
                                          tool = "Data Pack"),
                                          "File could not be read!")
 
@@ -27,7 +27,7 @@ test_that("Can error on bad file exstention", {
 
   foo_file <- tempfile(fileext = ".xlsb")
   file.create(foo_file)
-  expect_error(datapackr:::handshakeFile(foo_file,
+  expect_error(datapackr::handshakeFile(foo_file,
                                          tool = "Data Pack"),
                "File is not the correct format! File must have extension .xlsx")
   unlink(foo_file)

--- a/tests/testthat/test-resolve-dedupes.R
+++ b/tests/testthat/test-resolve-dedupes.R
@@ -86,7 +86,7 @@ test_that("Provide info only for  over-allocated pure dupes", {
 
 test_that("Can resolve non-overallocated crosswalk dupes", {
   foo <- list(data = list(), info = list())
-  foo$info$messages <- datapackr:::MessageQueue()
+  foo$info$messages <- datapackr::MessageQueue()
 
 
   foo$data$distributedMER <- tibble::tribble(
@@ -149,7 +149,7 @@ test_that("Provide info only for over-allocated crosswalk dupes", {
 
 test_that("Preserve non-deduplicated data when having over-allocated crosswalk dupes", {
   foo <- list(data = list(), info = list())
-  foo$info$messages <- datapackr:::MessageQueue()
+  foo$info$messages <- datapackr::MessageQueue()
 
 
   foo$data$distributedMER <- tibble::tribble(

--- a/tests/testthat/test-signature.R
+++ b/tests/testthat/test-signature.R
@@ -2,7 +2,7 @@ context("test-signature")
 
 
 test_that("Can generate a key chain", {
-  d <- datapackr:::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
+  d <- datapackr::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"),
                         tool = "Data Pack",
                         country_uids = NULL,
                         cop_year = NULL,
@@ -51,7 +51,7 @@ test_that("Can generate a key chain", {
 
 test_that("Can get the type and COP year of tool of a COP21 Data Pack", {
 
-   d <- datapackr:::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"))
+   d <- datapackr::createKeychainInfo(submission_path = test_sheet("COP21_Data_Pack_Template.xlsx"))
    expect_equal(d$info$tool, "Data Pack")
    expect_equal(d$info$cop_year, 2021)
 })

--- a/tests/testthat/test-unpack-COP21-datapack.R
+++ b/tests/testthat/test-unpack-COP21-datapack.R
@@ -5,7 +5,7 @@ d_data_tests_types <- c("tbl_df", "tbl", "data.frame")
 
 with_mock_api({
   test_that("Can unpack all data pack sheets", {
-    d <- datapackr:::createKeychainInfo(
+    d <- datapackr::createKeychainInfo(
       submission_path = test_sheet("COP21_DP_random_no_psnuxim.xlsx"),
       tool = "Data Pack",
       country_uids = NULL,
@@ -38,7 +38,7 @@ with_mock_api({
 
 with_mock_api({
   test_that("Can unpack and separate data sets", {
-    d <- datapackr:::createKeychainInfo(
+    d <- datapackr::createKeychainInfo(
       submission_path = test_sheet("COP21_DP_random_no_psnuxim.xlsx"),
       tool = "Data Pack",
       country_uids = NULL,


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Removes unnecessary usage of `:::` in function calls in favor of `::`.

### Related Issues
- DP-XXX
- etc.

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
