### PR TITLE
Align output folder parameters

### DIFF
--- a/R/create_play_spectrum_output.R
+++ b/R/create_play_spectrum_output.R
@@ -5,13 +5,7 @@
 #' Creates a fake Spectrum Data Pack export for use in testing with Data Packs.
 #' Requires login to DATIM.
 #'
-#' @param country_uids Unique IDs for countries to include in the Data Pack.
-#' For full list of these IDs, see \code{datapackr::dataPackMap}.
-#' @param  cop_year Specifies COP year for dating as well as selection of
-#' templates.
-#' @param output_folder Local folder where you would like your Data Pack to be
-#' saved upon export. If left as \code{NULL}, will not output externally.
-#' @param d2_session R6 datimutils object which handles authentication with DATIM
+#' @inheritParams datapackr_params
 #'
 #' @return Fake Spectrum dataset
 #'
@@ -185,7 +179,7 @@ create_play_spectrum_output <- function(country_uids,
     country_name <- datimutils::getOrgUnits(country_uids,
                                             d2_session = d2_session)
     exportPackr(data = play_spectrum_output,
-                output_path = output_folder,
+                output_folder = output_folder,
                 tool = "Spectrum Example",
                 datapack_name = country_name)
   }

--- a/R/exportPackr.R
+++ b/R/exportPackr.R
@@ -6,8 +6,6 @@
 #'
 #' @param data Data object to export. Can be either a dataframe or an Openxlsx
 #' Workbook object.
-#' @param output_path A local path directing to the folder where you would like
-#' outputs to be saved. If not supplied, will output to working directory.
 #' @param tool File prefix to be applied in output filename, as follows:
 #'   \describe{
 #'     \item{\code{Data Pack}}{Openxlsx Workbook object containing Data Pack.}
@@ -17,14 +15,13 @@
 #'     \item{\code{OPU Data Pack}}{Openxlsx Workbook object containing OPU Data Pack.}
 #'     \item{\code{Spectrum Example}}{Data frame containing example Spectrum output.}
 #' }
-#' @param datapack_name Name you would like associated with this Data Pack.
-#' (Example: "Western Hemisphere", or "Caribbean Region", or "Kenya".)
+#' @inheritParams datapackr_params
 #'
-exportPackr <- function(data, output_path, tool, datapack_name) {
-  packName <- function(output_path, tool, datapack_name, extension) {
+exportPackr <- function(data, output_folder, tool, datapack_name) {
+  packName <- function(output_folder, tool, datapack_name, extension) {
     paste0(
-      output_path,
-      if (is.na(stringr::str_extract(output_path, "/$"))) {
+      output_folder,
+      if (is.na(stringr::str_extract(output_folder, "/$"))) {
         "/"
       } else {
       },
@@ -41,7 +38,7 @@ exportPackr <- function(data, output_path, tool, datapack_name) {
       stop("Output type and data do not match!")
     }
 
-    output_file_name <- packName(output_path, tool, datapack_name, extension = ".xlsx")
+    output_file_name <- packName(output_folder, tool, datapack_name, extension = ".xlsx")
 
     openxlsx::saveWorkbook(wb = data, file = output_file_name, overwrite = TRUE)
   }
@@ -51,7 +48,7 @@ exportPackr <- function(data, output_path, tool, datapack_name) {
       stop("Output type and data do not match!")
     }
 
-    output_file_name <- packName(output_path, tool, datapack_name, extension = ".csv")
+    output_file_name <- packName(output_folder, tool, datapack_name, extension = ".csv")
 
     readr::write_csv(data, output_file_name)
   }
@@ -61,7 +58,7 @@ exportPackr <- function(data, output_path, tool, datapack_name) {
       stop("Output type and data do not match!")
     }
 
-    output_file_name <- packName(output_path, tool, datapack_name, extension = ".rds")
+    output_file_name <- packName(output_folder, tool, datapack_name, extension = ".rds")
 
     saveRDS(data, output_file_name)
   }

--- a/R/packDataPack.R
+++ b/R/packDataPack.R
@@ -5,21 +5,7 @@
 #' Takes a Data Pack template, combines it with data pulled from DATIM API, and
 #' produces a Data Pack ready for distribution.
 #'
-#' @param model_data Data from DATIM needed to pack into Data Pack
-#' @param datapack_name Name you would like associated with this Data Pack.
-#' (Example: "Western Hemisphere", or "Caribbean Region", or "Kenya".)
-#' @param country_uids Unique IDs for countries to include in the Data Pack.
-#' For full list of these IDs, see \code{datapackr::dataPackMap}.
-#' @param template_path Local filepath to Data Pack template Excel (XLSX) file.
-#' This file MUST NOT have any data validation formats present. If left
-#' \code{NULL}, will prompt for file selection via window.
-#' @param  cop_year Specifies COP year for dating as well as selection of
-#' templates.
-#' @param output_folder Local folder where you would like your Data Pack to be
-#' saved upon export.
-#' @param results_archive If TRUE, will export compiled results of all tests and
-#' processes to output_folder.
-#' @param d2_session DHIS2 Session id
+#' @inheritParams datapackr_params
 #'
 #' @return Exports a Data Pack to Excel within \code{output_folder}.
 #'
@@ -178,14 +164,14 @@ packDataPack <- function(model_data,
   # Save & Export Workbook
   interactive_print("Saving...")
   exportPackr(data = d$tool$wb,
-              output_path = d$keychain$output_folder,
+              output_folder = d$keychain$output_folder,
               tool = d$info$tool,
               datapack_name = d$info$datapack_name)
 
   # Save & Export Archive
   if (results_archive) {
     exportPackr(data = d,
-                output_path = d$keychain$output_folder,
+                output_folder = d$keychain$output_folder,
                 tool = "Results Archive",
                 datapack_name = d$info$datapack_name)
   }

--- a/R/packOPUDataPack.R
+++ b/R/packOPUDataPack.R
@@ -103,7 +103,7 @@ packOPUDataPack <- function(snuxim_model_data = NULL,
     # Save & Export Workbook
     print("Saving...")
     exportPackr(data = d$tool$wb,
-                output_path = d$keychain$output_folder,
+                output_folder = d$keychain$output_folder,
                 tool = d$info$tool,
                 datapack_name = d$info$datapack_name)
 
@@ -111,7 +111,7 @@ packOPUDataPack <- function(snuxim_model_data = NULL,
     if (results_archive) {
       print("Archiving...")
       exportPackr(data = d,
-                  output_path = d$keychain$output_folder,
+                  output_folder = d$keychain$output_folder,
                   tool = "Results Archive",
                   datapack_name = d$info$datapack_name)
     }

--- a/R/packageSetup.R
+++ b/R/packageSetup.R
@@ -219,8 +219,7 @@ pick_template_path <- function(cop_year, tool) {
 #' @param cop_year COP Year to use for tailoring functions. Remember,
 #' FY22 targets = COP21.
 #' @param output_folder Local folder where you would like your Data Pack to be
-#' saved upon export. If left as \code{NULL}, will output to
-#' \code{Working Directory}.
+#' saved upon export.
 #' @param results_archive If TRUE, will export compiled results of all tests and
 #' processes to output_folder.
 #' @param d2_session DHIS2 Session id

--- a/R/writePSNUxIM.R
+++ b/R/writePSNUxIM.R
@@ -4,13 +4,9 @@
 #' @description Checks a Data Pack for need of new or appended PSNUxIM data, then
 #' writes this into the Data Pack supplied. unPackTool must be run as prerequisite.
 #'
-#' @param d Datapackr object
-#' @param snuxim_model_data_path Filepath where SNU x IM distribution model is stored.
-#' @param output_folder Local folder where you would like your Data Pack to be
-#' saved upon export.
-#' @param d2_session R6 datimutils object which handles authentication with DATIM
 #' @param append If TRUE append rows to the existing DataPack otherwise,
 #' output a Missing PSNUxIM targets workbook.
+#' @inheritParams datapackr_params
 #' @return d
 #'
 writePSNUxIM <- function(d,
@@ -184,7 +180,7 @@ writePSNUxIM <- function(d,
     interactive_print("Exporting your new Data Pack...")
     exportPackr(
       data = d$tool$wb,
-      output_path = d$keychain$output_folder,
+      output_folder = d$keychain$output_folder,
       tool = "Data Pack",
       datapack_name = d$info$datapack_name)
 

--- a/data-raw/COP21OPU_Data_Pack_processing_script.R
+++ b/data-raw/COP21OPU_Data_Pack_processing_script.R
@@ -19,6 +19,6 @@ d <- unPackTool(tool = "OPU Data Pack", cop_year = 2021)
 
 # Export DATIM import files ####
   exportPackr(data = d$datim$MER,
-              output_path = output_folder,
+              output_folder = output_folder,
               type = "DATIM Export File",
               datapack_name = d$info$datapack_name)

--- a/data-raw/COP21_Data_Pack_processing_script.R
+++ b/data-raw/COP21_Data_Pack_processing_script.R
@@ -24,7 +24,7 @@ d <- writePSNUxIM(d, snuxim_model_data_path, output_folder)
 
 # Export DATIM import files ####
   exportPackr(data = d$datim$MER,
-              output_path = output_folder,
+              output_folder = output_folder,
               type = "DATIM Export File",
               datapack_name = d$info$datapack_name)
 
@@ -180,7 +180,7 @@ d <- writePSNUxIM(d, snuxim_model_data_path, output_folder)
 
   exportPackr(
     data = d$datim$MER,
-    output_path = d$keychain$output_folder,
+    output_folder = d$keychain$output_folder,
     type = "DATIM Export File",
     datapack_name = d$info$datapack_name
   )

--- a/data-raw/extract-spectrum-data.R
+++ b/data-raw/extract-spectrum-data.R
@@ -57,7 +57,7 @@ for (i in 1:length(spectrum_extracts)) {
   data <- spectrum_extracts[[i]]$data
   
   output_file_name <- 
-    paste0(output_path, "COP21SpectrumExtract_", country, ".csv")
+    paste0(output_folder, "COP21SpectrumExtract_", country, ".csv")
   
   readr::write_csv(data, output_file_name)
 }

--- a/man/create_play_spectrum_output.Rd
+++ b/man/create_play_spectrum_output.Rd
@@ -13,15 +13,15 @@ create_play_spectrum_output(
 }
 \arguments{
 \item{country_uids}{Unique IDs for countries to include in the Data Pack.
-For full list of these IDs, see \code{datapackr::dataPackMap}.}
+For full list of these IDs, see \code{datapackr::valid_PSNUs}.}
 
-\item{cop_year}{Specifies COP year for dating as well as selection of
-templates.}
+\item{cop_year}{COP Year to use for tailoring functions. Remember,
+FY22 targets = COP21.}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
-saved upon export. If left as \code{NULL}, will not output externally.}
+saved upon export.}
 
-\item{d2_session}{R6 datimutils object which handles authentication with DATIM}
+\item{d2_session}{DHIS2 Session id}
 }
 \value{
 Fake Spectrum dataset

--- a/man/datapackr_params.Rd
+++ b/man/datapackr_params.Rd
@@ -70,8 +70,7 @@ a cached copy of the mechanisms SQL view.}
 FY22 targets = COP21.}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
-saved upon export. If left as \code{NULL}, will output to
-\code{Working Directory}.}
+saved upon export.}
 
 \item{results_archive}{If TRUE, will export compiled results of all tests and
 processes to output_folder.}

--- a/man/exportPackr.Rd
+++ b/man/exportPackr.Rd
@@ -4,14 +4,14 @@
 \alias{exportPackr}
 \title{Export output.}
 \usage{
-exportPackr(data, output_path, tool, datapack_name)
+exportPackr(data, output_folder, tool, datapack_name)
 }
 \arguments{
 \item{data}{Data object to export. Can be either a dataframe or an Openxlsx
 Workbook object.}
 
-\item{output_path}{A local path directing to the folder where you would like
-outputs to be saved. If not supplied, will output to working directory.}
+\item{output_folder}{Local folder where you would like your Data Pack to be
+saved upon export.}
 
 \item{tool}{File prefix to be applied in output filename, as follows:
   \describe{

--- a/man/packDataPack.Rd
+++ b/man/packDataPack.Rd
@@ -16,20 +16,20 @@ packDataPack(
 )
 }
 \arguments{
-\item{model_data}{Data from DATIM needed to pack into Data Pack}
+\item{model_data}{Data from DATIM needed to pack into a COP Data Pack.}
 
 \item{datapack_name}{Name you would like associated with this Data Pack.
 (Example: "Western Hemisphere", or "Caribbean Region", or "Kenya".)}
 
 \item{country_uids}{Unique IDs for countries to include in the Data Pack.
-For full list of these IDs, see \code{datapackr::dataPackMap}.}
+For full list of these IDs, see \code{datapackr::valid_PSNUs}.}
 
 \item{template_path}{Local filepath to Data Pack template Excel (XLSX) file.
 This file MUST NOT have any data validation formats present. If left
-\code{NULL}, will prompt for file selection via window.}
+\code{NULL}, will select the default based on \code{cop_year} and \code{tool}.}
 
-\item{cop_year}{Specifies COP year for dating as well as selection of
-templates.}
+\item{cop_year}{COP Year to use for tailoring functions. Remember,
+FY22 targets = COP21.}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
 saved upon export.}

--- a/man/packOPUDataPack.Rd
+++ b/man/packOPUDataPack.Rd
@@ -33,8 +33,7 @@ This file MUST NOT have any data validation formats present. If left
 FY22 targets = COP21.}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
-saved upon export. If left as \code{NULL}, will output to
-\code{Working Directory}.}
+saved upon export.}
 
 \item{results_archive}{If TRUE, will export compiled results of all tests and
 processes to output_folder.}

--- a/man/parameter-checks.Rd
+++ b/man/parameter-checks.Rd
@@ -97,8 +97,7 @@ processes to output_folder.}
 mechanisms in the PSNUxIM tab}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
-saved upon export. If left as \code{NULL}, will output to
-\code{Working Directory}.}
+saved upon export.}
 
 \item{...}{Additional arguments to pass.}
 }

--- a/man/writePSNUxIM.Rd
+++ b/man/writePSNUxIM.Rd
@@ -13,14 +13,12 @@ writePSNUxIM(
 )
 }
 \arguments{
-\item{d}{Datapackr object}
-
-\item{snuxim_model_data_path}{Filepath where SNU x IM distribution model is stored.}
+\item{d}{Datapackr sidecar object}
 
 \item{output_folder}{Local folder where you would like your Data Pack to be
 saved upon export.}
 
-\item{d2_session}{R6 datimutils object which handles authentication with DATIM}
+\item{d2_session}{DHIS2 Session id}
 
 \item{append}{If TRUE append rows to the existing DataPack otherwise,
 output a Missing PSNUxIM targets workbook.}


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
* Changes `output_path` parameter in `exportPackr` to `output_folder`
* Replaces parameter names for `exportPackr` in all relevant locations
* Modifies `output_folder` definition in `datapackr_params` to remove outdated reference to defaulting to working directory.
* Removes duplicative parameter definitions in functions that were touched and replaces with inheritance from `datapackr_params`

### Related Issues
- DP-XXX
- etc.

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
