### PR TITLE
Add missing `d2_session` parameter

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -184,10 +184,13 @@ interactive_warning <- function(x) {
 #' @param datapack_uid A unique ID specifying the PEPFAR Operating Unit or
 #' specific Data Pack country grouping. If left unspecified, will pull all
 #' Country Names.
+#' @inheritParams datapackr_params
 #'
 #' @return Data frame of Countries
 #'
-getCountries <- function(datapack_uid = NA) {
+getCountries <- function(datapack_uid = NA,
+                         d2_session = dynGet("d2_default_session",
+                                             inherits = TRUE)) {
 
   # Pull Country List
     countries <-

--- a/man/getCountries.Rd
+++ b/man/getCountries.Rd
@@ -4,12 +4,17 @@
 \alias{getCountries}
 \title{Pull list of Countries from DATIM.}
 \usage{
-getCountries(datapack_uid = NA)
+getCountries(
+  datapack_uid = NA,
+  d2_session = dynGet("d2_default_session", inherits = TRUE)
+)
 }
 \arguments{
 \item{datapack_uid}{A unique ID specifying the PEPFAR Operating Unit or
 specific Data Pack country grouping. If left unspecified, will pull all
 Country Names.}
+
+\item{d2_session}{DHIS2 Session id}
 }
 \value{
 Data frame of Countries


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Adds missing `d2_session` parameter in `getCountries` function.

### Related Issues
- DP-XXX
- etc.

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
