### PR TITLE
HTS modalities analytics

### DIFF
--- a/R/checkAnalytics.R
+++ b/R/checkAnalytics.R
@@ -8,7 +8,7 @@ htsModalities <- function(cop_year) {
     # a reference to the cop year. Since the modalities
     # differ from year to year though, this list needs
     # to be determined based on the year we are dealing with.
-    datapackr::cop22_map_DataPack_DATIM_DEs_COCs %>%
+    datapackr::getMapDataPack_DATIM_DEs_COCs(cop_year) %>%
     dplyr::select(indicator_code, hts_modality) %>%
     dplyr::filter(!is.na(hts_modality)) %>%
     dplyr::distinct() %>%

--- a/R/checkAnalytics.R
+++ b/R/checkAnalytics.R
@@ -1,7 +1,7 @@
 
 
-htsModalities <- function() {
-    #TODO: This function needs a paramater based on COP year.
+htsModalities <- function(cop_year) {
+    #TODO: This function needs a parameter based on COP year.
     #More work further down, so I am not going to fix it
     #at the moment. Each of the checks is being fed a
     # data object, but this object does not seem to contain
@@ -367,9 +367,11 @@ analyze_retention <- function(data) {
 analyze_linkage <- function(data) {
   a <- NULL
 
+  hts_modalities <- htsModalities(data$cop_year[1])
+
   analysis <- data %>%
     dplyr::mutate(
-      HTS_TST_POS.T  = rowSums(dplyr::select(., tidyselect::any_of(htsModalities()))),
+      HTS_TST_POS.T  = rowSums(dplyr::select(., tidyselect::any_of(hts_modalities))),
       HTS_TST.Linkage.T =
         dplyr::case_when(
           HTS_TST_POS.T == 0 ~ NA_real_,
@@ -461,6 +463,8 @@ analyze_linkage <- function(data) {
 analyze_indexpos_ratio <- function(data) {
   a <- NULL
 
+  hts_modalities <- data$cop_year[1]
+
   analysis <- data %>%
     dplyr::filter(is.na(key_population)) %>%
     dplyr::select(-age, -sex, -key_population) %>%
@@ -468,7 +472,7 @@ analyze_indexpos_ratio <- function(data) {
     dplyr::summarise(dplyr::across(dplyr::everything(), sum)) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(
-      HTS_TST_POS.T = rowSums(dplyr::select(., tidyselect::any_of(htsModalities()))),
+      HTS_TST_POS.T = rowSums(dplyr::select(., tidyselect::any_of(hts_modalities))),
       HTS_INDEX.total =
         HTS_INDEX_COM.New.Pos.T
         + HTS_INDEX_FAC.New.Pos.T,
@@ -616,7 +620,8 @@ checkAnalytics <- function(d,
                 dplyr::pull(indicator_code)),
             type = "numeric") %>%
     dplyr::mutate(dplyr::across(c(-psnu, -psnu_uid, -age, -sex, -key_population),
-                     ~tidyr::replace_na(.x, 0)))
+                     ~tidyr::replace_na(.x, 0))) %>%
+    dplyr::mutate(cop_year = d$info$cop_year)
 
 
 

--- a/R/checkAnalytics.R
+++ b/R/checkAnalytics.R
@@ -1,6 +1,6 @@
 
 
-htsModalities <- function(cop_year) {
+HTS_POS_Modalities <- function(cop_year) {
     #TODO: This function needs a parameter based on COP year.
     #More work further down, so I am not going to fix it
     #at the moment. Each of the checks is being fed a
@@ -9,8 +9,9 @@ htsModalities <- function(cop_year) {
     # differ from year to year though, this list needs
     # to be determined based on the year we are dealing with.
     datapackr::getMapDataPack_DATIM_DEs_COCs(cop_year) %>%
-    dplyr::select(indicator_code, hts_modality) %>%
+    dplyr::select(indicator_code, hts_modality,resultstatus) %>%
     dplyr::filter(!is.na(hts_modality)) %>%
+    dplyr::filter(resultstatus %in% c("Newly Tested Positives", "Positive")) %>% 
     dplyr::distinct() %>%
     dplyr::pull(indicator_code)
 }
@@ -367,7 +368,7 @@ analyze_retention <- function(data) {
 analyze_linkage <- function(data) {
   a <- NULL
 
-  hts_modalities <- htsModalities(data$cop_year[1])
+  hts_modalities <- HTS_POS_Modalities(data$cop_year[1])
 
   analysis <- data %>%
     dplyr::mutate(
@@ -463,7 +464,7 @@ analyze_linkage <- function(data) {
 analyze_indexpos_ratio <- function(data) {
   a <- NULL
 
-  hts_modalities <- data$cop_year[1]
+  hts_modalities <- HTS_POS_Modalities(data$cop_year[1])
 
   analysis <- data %>%
     dplyr::filter(is.na(key_population)) %>%

--- a/R/checkAnalytics.R
+++ b/R/checkAnalytics.R
@@ -1,21 +1,18 @@
 
 
 htsModalities <- function() {
-c("HTS_INDEX_COM.New.Pos.T",
-          "HTS_INDEX_FAC.New.Pos.T",
-          "HTS_TST.EW.Pos.T",
-          "HTS_TST.Inpat.Pos.T",
-          "HTS_TST.Maln.Pos.T",
-          "HTS_TST.MobileCom.Pos.T",
-          "HTS_TST.OtherCom.Pos.T",
-          "HTS_TST.Other.Pos.T",
-          "HTS_TST.Peds.Pos.T",
-          "HTS_TST.PostANC1.Pos.T",
-          "HTS_TST.STI.Pos.T",
-          "HTS_TST.VCT.Pos.T",
-          "PMTCT_STAT.N.New.Pos.T",
-          "TB_STAT.N.New.Pos.T",
-          "VMMC_CIRC.Pos.T")
+    #TODO: This function needs a paramater based on COP year.
+    #More work further down, so I am not going to fix it
+    #at the moment. Each of the checks is being fed a
+    # data object, but this object does not seem to contain
+    # a reference to the cop year. Since the modalities
+    # differ from year to year though, this list needs
+    # to be determined based on the year we are dealing with.
+    datapackr::cop22_map_DataPack_DATIM_DEs_COCs %>%
+    dplyr::select(indicator_code, hts_modality) %>%
+    dplyr::filter(!is.na(hts_modality)) %>%
+    dplyr::distinct() %>%
+    dplyr::pull(indicator_code)
 }
 #' @export
 #' @title Check Data Pack for <90\% PMTCT_EID from ≤02 months

--- a/R/checkAnalytics.R
+++ b/R/checkAnalytics.R
@@ -9,9 +9,9 @@ HTS_POS_Modalities <- function(cop_year) {
     # differ from year to year though, this list needs
     # to be determined based on the year we are dealing with.
     datapackr::getMapDataPack_DATIM_DEs_COCs(cop_year) %>%
-    dplyr::select(indicator_code, hts_modality,resultstatus) %>%
+    dplyr::select(indicator_code, hts_modality, resultstatus) %>%
     dplyr::filter(!is.na(hts_modality)) %>%
-    dplyr::filter(resultstatus %in% c("Newly Tested Positives", "Positive")) %>% 
+    dplyr::filter(resultstatus %in% c("Newly Tested Positives", "Positive")) %>%
     dplyr::distinct() %>%
     dplyr::pull(indicator_code)
 }

--- a/tests/testthat/test-checkAnalytics.R
+++ b/tests/testthat/test-checkAnalytics.R
@@ -199,9 +199,9 @@ test_that(" Test retention > 100% expect message", {
 
 test_that(" Test retention  =  99% expect NULL", {
   data <- tribble(
-    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~TX_CURR.T, ~TX_CURR.T_1, ~TX_NEW.T,
-    "a", 1, "<1", "F", NA, 99, 100, 0,
-    "b", 2, "<1", "M", NA, 0, 0, 0
+    ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~TX_CURR.T, ~TX_CURR.T_1, ~TX_NEW.T, ~cop_year,
+    "a", 1, "<1", "F", NA, 99, 100, 0, 2021,
+    "b", 2, "<1", "M", NA, 0, 0, 0, 2021
   )
 
   expect_null(analyze_retention(data))
@@ -222,9 +222,9 @@ test_that(" Test retention all zeros expect NULL", {
 test_that(" Test linkage < 95% expect message", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, "25-49", "F", NA, 95, 5, 94, 0, 0,
-    "b", 2, "25-49", "M", NA, 95, 5, 95, 0, 0
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, "25-49", "F", NA, 95, 5, 94, 0, 0, 2021,
+    "b", 2, "25-49", "M", NA, 95, 5, 95, 0, 0, 2021
   )
 
   foo <- analyze_linkage(data)
@@ -237,9 +237,9 @@ test_that(" Test linkage < 95% expect message", {
 test_that(" Test KP linkage < 95% expect message", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 94,
-    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 95
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 94, 2021,
+    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 95, 2021
   )
 
   foo <- analyze_linkage(data)
@@ -252,9 +252,9 @@ test_that(" Test KP linkage < 95% expect message", {
 test_that(" Test linkage > 100% expect message", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-    ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, "25-49", "F", NA, 50, 50, 100, 0, 0,
-    "b", 2, "25-49", "M", NA, 50, 50, 101, 0, 0
+    ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, "25-49", "F", NA, 50, 50, 100, 0, 0, 2021,
+    "b", 2, "25-49", "M", NA, 50, 50, 101, 0, 0, 2021
   )
 
   foo <- analyze_linkage(data)
@@ -267,9 +267,9 @@ test_that(" Test linkage > 100% expect message", {
 test_that(" Test KP linkage > 100% expect message", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 100,
-    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 101
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 100, 2021,
+    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 101, 2021
   )
 
   foo <- analyze_linkage(data)
@@ -282,9 +282,9 @@ test_that(" Test KP linkage > 100% expect message", {
 test_that(" Test linkage = 98% expect NULL", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, "25-49", "F", NA, 20, 20, 39, 0, 0,
-    "b", 2, "25-49", "M", NA, 0, 0, 0, 0, 0
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, "25-49", "F", NA, 20, 20, 39, 0, 0, 2021,
+    "b", 2, "25-49", "M", NA, 0, 0, 0, 0, 0, 2021
   )
 
   expect_null(analyze_linkage(data))
@@ -294,9 +294,9 @@ test_that(" Test linkage = 98% expect NULL", {
 test_that(" Test KP linkage = 98% expect NULL", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 98,
-    "b", 2, NA, NA, "PWID", 0, 0, 0, 0, 0
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, NA, NA, "PWID", 0, 0, 0, 100, 98, 2021,
+    "b", 2, NA, NA, "PWID", 0, 0, 0, 0, 0, 2021
   )
 
   expect_null(analyze_linkage(data))
@@ -306,9 +306,9 @@ test_that(" Test KP linkage = 98% expect NULL", {
 test_that(" Test linkage all zeros expect NULL", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-    ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, "25-49", "F", NA, 0, 0, 0, 0, 0,
-    "b", 2, "25-49", "M", NA, 0, 0, 0, 0, 0
+    ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, "25-49", "F", NA, 0, 0, 0, 0, 0, 2021,
+    "b", 2, "25-49", "M", NA, 0, 0, 0, 0, 0, 2021
   )
 
   expect_null(analyze_linkage(data))
@@ -318,9 +318,9 @@ test_that(" Test linkage all zeros expect NULL", {
 test_that(" Test linkage with age <1", {
   data <- tribble(
     ~psnu, ~psnu_uid, ~age, ~sex, ~key_population, ~HTS_INDEX_COM.New.Pos.T,
-     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T,
-    "a", 1, "<01", "M", NA, 50, 50, 101, 100, 100,
-    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 101
+     ~HTS_INDEX_FAC.New.Pos.T, ~TX_NEW.T, ~HTS_TST.KP.Pos.T, ~TX_NEW.KP.T, ~cop_year,
+    "a", 1, "<01", "M", NA, 50, 50, 101, 100, 100, 2021,
+    "b", 2, NA, NA, "PWID", 0, 0, 0, 100, 101, 2021
   )
 
   foo <- analyze_linkage(data)


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->
- Both the retention and linkage analytics checks do not work properly with the finer 50+ age bands. HTS_TST and TX_CURR data needs to be collapsed back to 50+ when combined with model data or other indicators from the DataPack which are not allocated at these finer age bands. 

- HTS modalities for the checkAnalytics functions were hard-coded to COP21. This resulted in problems in the analytics checks which involved HTS modalities for COP22 data.
### Related Issues



<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
