### PR TITLE
Add warning on extra PSNUxIM columns

### DIFF
--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -241,7 +241,7 @@ unPackSNUxIM <- function(d) {
  #  Realistically, we should be able to handle missing columns, but for now,
  # the check will remain strict until further changes are made here.
 
-  if (NCOL(d$data$SNUxIM) != max(cols_to_keep$col)) {
+  if (NCOL(d$data$SNUxIM) < max(cols_to_keep$col)) {
     stop(
       paste(
         "ERROR: Missing columns in the PSNUxIM tab. Please ensure that there are exactly",
@@ -254,6 +254,19 @@ unPackSNUxIM <- function(d) {
       )
     )
   }
+
+  if (NCOL(d$data$SNUxIM) > max(cols_to_keep$col)) {
+        warning_msg <-
+          paste(
+            "WARNING: Extra columns in the PSNUxIM tab. Please ensure that there are exactly",
+            max(cols_to_keep$col), "columns in the PSNUxIM tab for your final submissions. Please review columns",
+            cellranger::num_to_letter(max(cols_to_keep$col) + 1), "to columns",
+            cellranger::num_to_letter(NCOL(d$data$SNUxIM))
+            )
+
+        d$info$messages <- appendMessage(d$info$messages, warning_msg, "WARNING")
+  }
+
 
   # Pare down to populated, updated targets only ####
 


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->
- Warn only when the number of columns in the PSNUxIM tab exceed the number of template columns. 
- 
### Related Issues
- https://datim.zendesk.com/agent/tickets/46066


<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
