### PR TITLE
Validate DataPackTarget column

### DIFF
--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -272,7 +272,7 @@ unPackSNUxIM <- function(d) {
     #matches the data in the main tabs
 
     main_tab_data <- original_targets %>%
-      dplyr::select(PSNU,indicator_code, Age, Sex, KeyPop, MainTabsTarget = value) %>%
+      dplyr::select(PSNU, indicator_code, Age, Sex, KeyPop, MainTabsTarget = value) %>%
       dplyr::filter(!indicator_code %in% c("AGYW_PREV.D.T", "AGYW_PREV.N.T")) %>%
       # Special handling for differences between main tab and PSNUxIM tab age bands
       # and the original tabs
@@ -285,9 +285,9 @@ unPackSNUxIM <- function(d) {
       dplyr::summarise(MainTabsTarget = sum(MainTabsTarget, na.rm = TRUE), .groups = "drop")
 
     d$tests$non_equal_targets  <- d$data$SNUxIM %>%
-      dplyr::select(PSNU,indicator_code,Age,Sex,KeyPop,DataPackTarget) %>%
+      dplyr::select(PSNU, indicator_code ,Age, Sex, KeyPop, DataPackTarget) %>%
       dplyr::mutate(DataPackTarget = as.numeric(DataPackTarget)) %>%
-      dplyr::full_join(main_tab_data, by=c("PSNU", "indicator_code", "Age", "Sex", "KeyPop")) %>%
+      dplyr::full_join(main_tab_data, by = c("PSNU", "indicator_code", "Age", "Sex", "KeyPop")) %>%
       dplyr::mutate(are_equal = dplyr::near(DataPackTarget, MainTabsTarget, tol = 0.1)) %>%
       #If the main tab value is missing and the DataPackTarget is zero, ignore
       dplyr::mutate(are_equal = dplyr::case_when(is.na(MainTabsTarget) & DataPackTarget == 0 ~ TRUE,

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -285,7 +285,7 @@ unPackSNUxIM <- function(d) {
       dplyr::summarise(MainTabsTarget = sum(MainTabsTarget, na.rm = TRUE), .groups = "drop")
 
     d$tests$non_equal_targets  <- d$data$SNUxIM %>%
-      dplyr::select(PSNU, indicator_code ,Age, Sex, KeyPop, DataPackTarget) %>%
+      dplyr::select(PSNU, indicator_code, Age, Sex, KeyPop, DataPackTarget) %>%
       dplyr::mutate(DataPackTarget = as.numeric(DataPackTarget)) %>%
       dplyr::full_join(main_tab_data, by = c("PSNU", "indicator_code", "Age", "Sex", "KeyPop")) %>%
       dplyr::mutate(are_equal = dplyr::near(DataPackTarget, MainTabsTarget, tol = 0.1)) %>%

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -267,13 +267,12 @@ unPackSNUxIM <- function(d) {
         d$info$messages <- appendMessage(d$info$messages, warning_msg, "WARNING")
   }
 
-
   if (d$info$tool == "Data Pack") {
     #Check to ensure that the value in column G (DataPack Target) actually
     #matches the data in the main tabs
-    
-    main_tab_data <- original_targets %>% 
-      dplyr::select(PSNU,indicator_code,Age,Sex,KeyPop,MainTabsTarget = value) %>%
+
+    main_tab_data <- original_targets %>%
+      dplyr::select(PSNU,indicator_code, Age, Sex, KeyPop, MainTabsTarget = value) %>%
       dplyr::filter(!indicator_code %in% c("AGYW_PREV.D.T", "AGYW_PREV.N.T")) %>%
       # Special handling for differences between main tab and PSNUxIM tab age bands
       # and the original tabs
@@ -281,43 +280,43 @@ unPackSNUxIM <- function(d) {
         stringr::str_detect(Age, "(50-54|55-59|60-64|65+)") &
           !stringr::str_detect(indicator_code, "TX_CURR.T") ~ "50+",
         TRUE ~ Age
-      )) %>% 
-      dplyr::group_by(dplyr::across(c(-MainTabsTarget))) %>% 
-      dplyr::summarise(MainTabsTarget = sum(MainTabsTarget, na.rm = TRUE), .groups="drop")
-    
+      )) %>%
+      dplyr::group_by(dplyr::across(c(-MainTabsTarget))) %>%
+      dplyr::summarise(MainTabsTarget = sum(MainTabsTarget, na.rm = TRUE), .groups = "drop")
+
     d$tests$non_equal_targets  <- d$data$SNUxIM %>%
-      dplyr::select(PSNU,indicator_code,Age,Sex,KeyPop,DataPackTarget) %>% 
-      dplyr::mutate(DataPackTarget = as.numeric(DataPackTarget)) %>% 
-      dplyr::full_join(main_tab_data, by=c("PSNU","indicator_code","Age","Sex","KeyPop")) %>% 
-      dplyr::mutate(are_equal = dplyr::near(DataPackTarget,MainTabsTarget, tol=0.1) ) %>% 
+      dplyr::select(PSNU,indicator_code,Age,Sex,KeyPop,DataPackTarget) %>%
+      dplyr::mutate(DataPackTarget = as.numeric(DataPackTarget)) %>%
+      dplyr::full_join(main_tab_data, by=c("PSNU", "indicator_code", "Age", "Sex", "KeyPop")) %>%
+      dplyr::mutate(are_equal = dplyr::near(DataPackTarget, MainTabsTarget, tol = 0.1)) %>%
       #If the main tab value is missing and the DataPackTarget is zero, ignore
       dplyr::mutate(are_equal = dplyr::case_when(is.na(MainTabsTarget) & DataPackTarget == 0 ~ TRUE,
                                                  is.na(MainTabsTarget) & DataPackTarget != 0 ~ FALSE,
-                                                 TRUE ~ are_equal)) %>% 
-      dplyr::filter(!are_equal | is.na(are_equal)) %>% 
+                                                 TRUE ~ are_equal)) %>%
+      dplyr::filter(!are_equal | is.na(are_equal)) %>%
       #Filter non-allocated data to prevent false positives with this test
       #Other tests should catch whether there is data in the main tabs
       #but which has not been allocated
       dplyr::filter(!is.na(DataPackTarget))
-    
+
     attr(d$tests$non_equal_targets, "test_name") <- "Non-equal targets"
-    
+
     if (NROW(d$tests$non_equal_targets) > 0) {
       warning_msg <-
-        paste0(
-          "ERROR! In tab PSNUxIM:",NROW(d$tests$non_equal_targets), 
-          "instances of values in column G (DataPackTargets) which do not
-          equal the targets set in the main tabs. Please check to ensure 
-          that the formulas in column G are correct. Please
-          download a copy of the validation report from the sel and 
-          consult the tab non_equal_targets for details.\n")
-      
+        paste(
+          "ERROR! In tab PSNUxIM:", NROW(d$tests$non_equal_targets),
+          "instances of values in column G (DataPackTargets) which do not",
+          "equal the targets set in the main tabs. Please check to ensure",
+          "that the formulas in column G are correct. Please",
+          "download a copy of the validation report from the self-service app",
+          "and consult the tab non_equal_targets for details.\n")
+
       d$info$messages <- appendMessage(d$info$messages, warning_msg, "ERROR")
     }
-    
+
   }
 
-  
+
 
   # Pare down to populated, updated targets only ####
 


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->

- In certain situations the DataPackTarget column may become corrupted by alteration of the formula. This test ensure that the values in the DataPackTarget column in the PSNUxIM tab match those in each of the main tabs which they reference. In the case of finer 50+ age bands, the values are aggregated from the main tabs to 50+ (with the exception of TX_CURR which is left as is). 
- The test excludes non-allocated data, as this is tested for elsewhere. 
- There is some overlap with the test for "unbalanced distribution". However, this test is really looking for instances when the values which have been allocated do match due to rounding issues. 

### Related Issues
- DP-XXX
- etc.

<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
