### PR TITLE
DP-662: Reduce cylomatic complexity of `packSNUxIM`

### DIFF
--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -15,7 +15,11 @@ packSNUxIM <- function(d,
 
   # Check if SNUxIM data already exists ####
   if (NROW(d$data$SNUxIM) == 1 & is.na(d$data$SNUxIM$PSNU[1])) {
+    ## If no PSNUxIM tab, set has_psnuxim to FALSE and set target_data equal to all MER dataset ####
     d$info$has_psnuxim <- FALSE
+    targets_data <- d$data$MER
+  } else {
+    d$info$has_psnuxim <- TRUE
     ## If does exist, extract missing combos ####
     d$data$missingCombos <- d$data$MER %>%
       # TODO: Create this here rather than upstream
@@ -30,13 +34,9 @@ packSNUxIM <- function(d,
       ## If tool has PSNUxIM tab and missing combos, SNUxIM model data should include only missing combos ####
       targets_data <- d$data$missingCombos
     }
-  } else {
-    ## If no PSNUxIM tab, set has_psnuxim to FALSE and set target_data equal to all MER dataset ####
-    d$info$has_psnuxim <- TRUE
-    targets_data <- d$data$MER
   }
 
-    #TODO: Consider preparing this ahead of time for all OUs
+  #TODO: Consider preparing this ahead of time for all OUs
   snuxim_model_data <- readRDS(d$keychain$snuxim_model_data_path) %>%
     prepare_model_data.PSNUxIM(snuxim_model_data = .,
                                country_uids = d$info$country_uids)

--- a/R/packSNUxIM.R
+++ b/R/packSNUxIM.R
@@ -11,35 +11,28 @@ packSNUxIM <- function(d,
                        d2_session = dynGet("d2_default_session",
                                            inherits = TRUE)) {
 
-  if (!d$info$cop_year %in% c(2021)) {
-    stop(paste0("Packing SNU x IM tabs is not supported for COP ", d$info$cop_year, " Data Packs."))
-  }
+  stopifnot("Packing SNU x IM tabs is only supported for COP21 Data Packs." = d$info$cop_year == 2021)
 
   # Check if SNUxIM data already exists ####
   if (NROW(d$data$SNUxIM) == 1 & is.na(d$data$SNUxIM$PSNU[1])) {
     d$info$has_psnuxim <- FALSE
-  } else {
-    d$info$has_psnuxim <- TRUE
-  }
-
-  # If does exist, extract missing combos ####
-  if (d$info$has_psnuxim) {
+    ## If does exist, extract missing combos ####
     d$data$missingCombos <- d$data$MER %>%
       # TODO: Create this here rather than upstream
       dplyr::anti_join(d$data$PSNUxIM_combos)
 
     d$info$missing_psnuxim_combos <- (NROW(d$data$missingCombos) > 0)
-  }
 
-  # Proceed IFF no PSNU x IM tab exists, or exists but with missing combos ####
-  if (d$info$has_psnuxim & !d$info$missing_psnuxim_combos) {
-    return(d)
-  }
-
-  # Prepare SNU x IM model dataset ####
-  if (d$info$has_psnuxim & d$info$missing_psnuxim_combos) {
-    targets_data <- d$data$missingCombos
+    if (!d$info$missing_psnuxim_combos) {
+      ## If tool has PSNUxIM tab and not missing any combos, exit and return d object. ####
+      return(d)
+    } else {
+      ## If tool has PSNUxIM tab and missing combos, SNUxIM model data should include only missing combos ####
+      targets_data <- d$data$missingCombos
+    }
   } else {
+    ## If no PSNUxIM tab, set has_psnuxim to FALSE and set target_data equal to all MER dataset ####
+    d$info$has_psnuxim <- TRUE
     targets_data <- d$data$MER
   }
 


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Reduces the cyclomatic complexity of the `packSNUxIM` function below 15 to ensure that it no longer trips linter:
* Simplifies check for proper COP year to use `stopifnot`
* Simplifies the series of if-else statements at the top of the function for checking if PSNUxIM tab exists and if there are any missing PSNUxIM combos to be written to the tool

### Related Issues
- DP-662

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
