### PR TITLE
DP-667: Reduce cyclo complexity of `writePSNUxIM`

### DIFF
--- a/R/writePSNUxIM.R
+++ b/R/writePSNUxIM.R
@@ -1,5 +1,5 @@
 #' @export
-#' @title writePSNUxIM(d)
+#' @title Write PSNUxIM Tab
 #'
 #' @description Checks a Data Pack for need of new or appended PSNUxIM data, then
 #' writes this into the Data Pack supplied. unPackTool must be run as prerequisite.
@@ -12,18 +12,19 @@
 #' @return d
 #'
 writePSNUxIM <- function(d,
-                        snuxim_model_data_path = NULL,
-                        output_folder = NULL,
-                        d2_session = dynGet("d2_default_session",
-                                            inherits = TRUE),
-                        append = TRUE) {
+                         snuxim_model_data_path = NULL,
+                         output_folder = NULL,
+                         d2_session = dynGet("d2_default_session",
+                                             inherits = TRUE),
+                         append = TRUE) {
+
+  stopifnot(
+    "Cannot update PSNUxIM tab without model data." = !is.null(snuxim_model_data_path),
+    "Packing SNU x IM tabs is not supported for the requested COP year." = !d$info$cop_year %in% c(2021, 2022)
+  )
 
   if (is.null(output_folder)) {
     interactive_warning("If no output_folder is provided, new Data Packs will not be written.")
-  }
-
-  if (is.null(snuxim_model_data_path)) {
-    stop("Cannot update PSNUxIM tab without model data.")
   }
 
   d$keychain$snuxim_model_data_path <- snuxim_model_data_path
@@ -59,7 +60,7 @@ writePSNUxIM <- function(d,
   # Check whether to write anything into SNU x IM tab and write if needed ####
   if (d$info$cop_year == 2021) {
     d <- packSNUxIM(d, d2_session = d2_session)
-  } else if (d$info$cop_year == 2022) {
+  } else {
   # Prepare data to distribute ####
     d$info$has_psnuxim <- !(NROW(d$data$SNUxIM) == 1 & is.na(d$data$SNUxIM$PSNU[1]))
 
@@ -161,8 +162,6 @@ writePSNUxIM <- function(d,
     d$info$messages <- appendMessage(d$info$messages, r$message, r$level)
     d$info$newSNUxIM <- TRUE
 
-  } else {
-    stop(paste0("Packing SNU x IM tabs is not supported for COP ", d$info$cop_year, " Data Packs."))
   }
 
   # If new information added to SNU x IM tab, reexport Data Pack for user ####

--- a/man/writePSNUxIM.Rd
+++ b/man/writePSNUxIM.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/writePSNUxIM.R
 \name{writePSNUxIM}
 \alias{writePSNUxIM}
-\title{writePSNUxIM(d)}
+\title{Write PSNUxIM Tab}
 \usage{
 writePSNUxIM(
   d,


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Replicates PR #478 to clean up `dev` for release 5.2.2
Reduces the cyclomatic complexity of `writePSNUxIM` function:
- Moves all `stop` criteria to the top of the function and combines them into a single `stopifnot` call
- Fixes function name

### Related Issues
- DP-667

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
