### PR TITLE
DP-661: Reduces cyclo complexity of `packPSNUxIM`

### DIFF
--- a/R/packPSNUxIM.R
+++ b/R/packPSNUxIM.R
@@ -29,9 +29,8 @@ packPSNUxIM <- function(wb, # Workbook object
 
   rm(params, p)
 
-  if (!cop_year %in% c(2021, 2022)) { # if the cop year is not 2021 or 2022, stops and throws message.
-    stop(paste0("Packing PSNU x IM tabs is not supported for COP", cop_year, " Data Packs."))
-  }
+  # if the cop year is not 2021 or 2022, stops and throws message. ####
+  stopifnot("Packing PSNU x IM tabs is not supported for the requested COP year." = cop_year %in% c(2021, 2022))
 
   # Create data sidecar to eventually compile and return ####
   r <- list(
@@ -120,9 +119,7 @@ packPSNUxIM <- function(wb, # Workbook object
     dplyr::ungroup()
 
   # Throws a warning to the user if the number rows do not match after munging.
-  if (NROW(percents) != NROW(values)) {
-    stop("Aggregating values and percents led to different row counts!")
-  }
+  stopifnot("Aggregating values and percents led to different row counts!" = NROW(percents) == NROW(values))
 
   snuxim_model_data <- values %>% # Joins percents to values
     dplyr::left_join(percents,


### PR DESCRIPTION
## Developer:

### Summary of Proposed Changes
Decreases the cyclomatic complexity of the function `packPSNUxIM` function by switching from if-else checks for stop conditions to using `stopifnot`.
Replicates PR #475 to clean up `dev` for release 5.2.2.

### Related Issues
- DP-661

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
