### PR TITLE
Fix negative values test.

### DIFF
--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -39,7 +39,8 @@ unPackDataPackSheet <- function(d,
   header_cols <- keep_cols %>%
     dplyr::filter(col_type == "row_header")
 
-  data <- d$sheets[names(d$sheets) %in% sheets] %>%
+  data <- d$sheets %>%
+    purrr::keep(names(.) %in% sheets) %>%
     purrr::map2_dfr(
       .,
       names(.),
@@ -92,7 +93,10 @@ unPackDataPackSheet <- function(d,
   if (clean_values) {
     data %<>%
       dplyr::mutate(
-        value = suppressWarnings(as.numeric(value))) %>% # Convert to numeric ----
+        # NOTE: This is the initial conversion to numeric.
+        # Determine what the furture consequences of this are
+        # If this function is called with clean_values.
+        value = suppressWarnings(as.numeric(value))) %>%
       tidyr::drop_na(value) # Drop NAs & non-numerics ----
 
     # Clean Prioritizations ----

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -39,8 +39,7 @@ unPackDataPackSheet <- function(d,
   header_cols <- keep_cols %>%
     dplyr::filter(col_type == "row_header")
 
-  data <- d$sheets %>%
-    purrr::keep(names(.) %in% sheets) %>%
+  data <- d$sheets[names(d$sheets) %in% sheets] %>%
     purrr::map2_dfr(
       .,
       names(.),
@@ -93,9 +92,6 @@ unPackDataPackSheet <- function(d,
   if (clean_values) {
     data %<>%
       dplyr::mutate(
-        # NOTE: This is the initial conversion to numeric.
-        # Determine what the furture consequences of this are
-        # If this function is called with clean_values.
         value = suppressWarnings(as.numeric(value))) %>%
       tidyr::drop_na(value) # Drop NAs & non-numerics ----
 

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -635,7 +635,7 @@ checkNegativeValues <- function(sheets, d, quiet = T) {
                                          clean_orgs = F,
                                          clean_disaggs = F,
                                          clean_values = F) %>% #Are the values numeric at this point?
-    dplyr::filter(stringr::str_detect(value,"^-"))
+    dplyr::filter(stringr::str_detect(value, "^-"))
 
   if (NROW(negative_values) > 0) {
 

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -469,7 +469,8 @@ checkOutOfOrderCols <- function(sheets, d, quiet = TRUE) {
             lvl = NULL,
             has_error = FALSE)
 
-  out_of_order <- d$sheets[sheets] %>%
+  out_of_order <- d$sheets %>%
+    purrr::keep(names(.) %in% sheets) %>%
     purrr::map2_dfr(
       .,
       names(.),
@@ -634,8 +635,12 @@ checkNegativeValues <- function(sheets, d, quiet = T) {
                                          sheets,
                                          clean_orgs = F,
                                          clean_disaggs = F,
-                                         clean_values = F) %>% #Are the values numeric at this point?
-    dplyr::filter(stringr::str_detect(value, "^-"))
+                                         clean_values = F) %>%
+    #TODO: Keeping this consistent with checkDecimalValues
+    #Consider doing the numeric conversion once in unPackDataSheet
+    #instead of multiple times in these checks.
+    dplyr::mutate(value = suppressWarnings(as.numeric(value))) %>%
+    dplyr::filter(value < 0)
 
   if (NROW(negative_values) > 0) {
 

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -557,9 +557,9 @@ checkNonNumeric <- function(sheets, d, quiet = TRUE) {
 
   non_numeric <- unPackDataPackSheet(d,
                                      sheets,
-                                     clean_orgs = F,
-                                     clean_disaggs = F,
-                                     clean_values = F) %>%
+                                     clean_orgs = FALSE,
+                                     clean_disaggs = FALSE,
+                                     clean_values = FALSE) %>%
     dplyr::filter(
       !(sheet_name == "Prioritization"
         & stringr::str_sub(PSNU, 1, 9) == "_Military")) %>%
@@ -624,7 +624,7 @@ checkNonNumeric <- function(sheets, d, quiet = TRUE) {
 
 #' @export
 #' @rdname unPackDataChecks
-checkNegativeValues <- function(sheets, d, quiet = T) {
+checkNegativeValues <- function(sheets, d, quiet = TRUE) {
 
   ch <- list(result = NULL,
             msg = NULL,
@@ -633,9 +633,9 @@ checkNegativeValues <- function(sheets, d, quiet = T) {
 
   negative_values <- unPackDataPackSheet(d,
                                          sheets,
-                                         clean_orgs = F,
-                                         clean_disaggs = F,
-                                         clean_values = F) %>%
+                                         clean_orgs = FALSE,
+                                         clean_disaggs = FALSE,
+                                         clean_values = FALSE) %>%
     #TODO: Keeping this consistent with checkDecimalValues
     #Consider doing the numeric conversion once in unPackDataSheet
     #instead of multiple times in these checks.
@@ -695,9 +695,9 @@ checkDecimalValues <- function(sheets, d, quiet = TRUE) {
 
   decimal_cols <- unPackDataPackSheet(d,
                                       sheets,
-                                      clean_orgs = F,
-                                      clean_disaggs = F,
-                                      clean_values = F) %>%
+                                      clean_orgs = FALSE,
+                                      clean_disaggs = FALSE,
+                                      clean_values = FALSE) %>%
     dplyr::mutate(value = suppressWarnings(as.numeric(value))) %>%
     dplyr::filter(value %% 1 != 0
                   & !indicator_code %in% decimals_allowed)
@@ -754,7 +754,7 @@ checkInvalidOrgUnits <- function(sheets, d, quiet = TRUE) {
 
   na_orgunits <- invalid_orgunits[is.na(invalid_orgunits$PSNU), ]
 
-  if (NROW(invalid_orgunits) > 0 | NROW(na_orgunits) > 0) {
+  if (NROW(invalid_orgunits) > 0 || NROW(na_orgunits) > 0) {
 
     ch$lvl <- "ERROR"
 
@@ -797,7 +797,7 @@ checkInvalidOrgUnits <- function(sheets, d, quiet = TRUE) {
 
 #' @export
 #' @rdname unPackDataChecks
-checkInvalidPrioritizations <- function(sheets, d, quiet = T) {
+checkInvalidPrioritizations <- function(sheets, d, quiet = TRUE) {
 
   ch <- list(result = NULL,
             msg = NULL,
@@ -889,7 +889,7 @@ checkFormulas <- function(sheets, d, quiet = TRUE) {
   formulas_datapack <-
     tidyxl::xlsx_cells(path = d$keychain$submission_path,
                        sheets = sheets,
-                       include_blank_cells = T) %>%
+                       include_blank_cells = TRUE) %>%
     # Note that this function won't pick up any cols with blank indicator_code
     dplyr::filter(row >= header_row) %>%
     dplyr::mutate(formula = dplyr::if_else(is.na(formula),

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -469,8 +469,7 @@ checkOutOfOrderCols <- function(sheets, d, quiet = TRUE) {
             lvl = NULL,
             has_error = FALSE)
 
-  out_of_order <- d$sheets %>%
-    purrr::keep(names(.) %in% sheets) %>%
+  out_of_order <- d$sheets[names(d$sheets) %in% sheets] %>%
     purrr::map2_dfr(
       .,
       names(.),

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -634,8 +634,8 @@ checkNegativeValues <- function(sheets, d, quiet = T) {
                                          sheets,
                                          clean_orgs = F,
                                          clean_disaggs = F,
-                                         clean_values = F) %>%
-    dplyr::filter(value < 0)
+                                         clean_values = F) %>% #Are the values numeric at this point?
+    dplyr::filter(stringr::str_detect(value,"^-"))
 
   if (NROW(negative_values) > 0) {
 

--- a/tests/testthat/test-unPackingChecks.R
+++ b/tests/testthat/test-unPackingChecks.R
@@ -110,7 +110,7 @@ test_that("Can check sheet data...", {
   expect_gt(nrow(d$tests$duplicate_columns), 0)
   expect_gt(nrow(d$tests$columns_out_of_order), 0)
   expect_gt(nrow(d$tests$non_numeric), 0)
-  expect_gt(nrow(d$tests$negative_values), 0)
+  expect_equal(nrow(d$tests$negative_values), 6L)
   expect_gt(nrow(d$tests$decimal_values), 0)
   expect_gt(nrow(d$tests$invalid_orgunits), 0)
   expect_gt(nrow(d$tests$invalid_prioritizations), 0)


### PR DESCRIPTION
Speculative fix for tests for negative values.  I was not certain that the values in the `value` column were actually cast to numeric before the `value < 0` comparison, so used a string based regex comparison to detect values which start with `-`. This may explain the test differences in different enviornments.