### PR TITLE
Dp 784 hotfix

### DIFF
--- a/R/createKeychainInfo.R
+++ b/R/createKeychainInfo.R
@@ -118,7 +118,7 @@ createKeychainInfo <- function(submission_path = NULL,
 
   d$info$country_uids <- d$info$country_uids %||% submitted_country_uids
 
-  if (d$info$country_uids != submitted_country_uids) {
+  if (!identical(d$info$country_uids, submitted_country_uids)) {
     stop("The file submitted does not seem to match the country_uids you've specified.")
   }
 

--- a/R/loadDataPack.R
+++ b/R/loadDataPack.R
@@ -90,6 +90,9 @@ readSheet <- function(d,
 
   # kill excess rows where all data is NULL, base R for speed
   data <- data[rowSums(is.na(data)) != ncol(data),]
+  # kill empty column names
+  keep.cols <- names(data) %in% c("")
+  data <-data[! keep.cols]
 
   data
 

--- a/R/loadDataPack.R
+++ b/R/loadDataPack.R
@@ -88,6 +88,9 @@ readSheet <- function(d,
       progress = progress,
       .name_repair = .name_repair)
 
+  # kill excess rows where all data is NULL, base R for speed
+  data <- data[rowSums(is.na(data)) != ncol(data),]
+
   data
 
 }

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -57,8 +57,8 @@ unPackDataPackSheet <- function(d,
         tibble::add_column(sheet_name = y)) %>% # Tag sheet name ----
   # Add cols to allow compiling with other sheets ----
     addcols(c("KeyPop", "Age", "Sex")) %>%
-    #dplyr::mutate(psnuid = extract_uid(PSNU)) %>% # Extract PSNU uid ----
-    dplyr::mutate(psnuid = purrr::pmap_chr(list(PSNU), extract_uid)) %>% # Extract PSNU uid ----
+    dplyr::mutate(psnuid = extract_uid(PSNU)) %>% # Extract PSNU uid ----
+    #dplyr::mutate(psnuid = purrr::pmap_chr(list(PSNU), extract_uid)) %>% # Extract PSNU uid ----
     dplyr::select(PSNU, psnuid, sheet_name, indicator_code, Age, Sex, KeyPop, value) %>%
     tidyr::drop_na(value)
 

--- a/R/unPackSheet.R
+++ b/R/unPackSheet.R
@@ -57,7 +57,8 @@ unPackDataPackSheet <- function(d,
         tibble::add_column(sheet_name = y)) %>% # Tag sheet name ----
   # Add cols to allow compiling with other sheets ----
     addcols(c("KeyPop", "Age", "Sex")) %>%
-    dplyr::mutate(psnuid = extract_uid(PSNU)) %>% # Extract PSNU uid ----
+    #dplyr::mutate(psnuid = extract_uid(PSNU)) %>% # Extract PSNU uid ----
+    dplyr::mutate(psnuid = purrr::pmap_chr(list(PSNU), extract_uid)) %>% # Extract PSNU uid ----
     dplyr::select(PSNU, psnuid, sheet_name, indicator_code, Age, Sex, KeyPop, value) %>%
     tidyr::drop_na(value)
 

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -744,7 +744,7 @@ checkInvalidOrgUnits <- function(sheets, d, quiet = TRUE) {
             lvl = NULL,
             has_error = FALSE)
 
-  invalid_orgunits <<- d$sheets[sheets] %>%
+  invalid_orgunits <- d$sheets[sheets] %>%
     dplyr::bind_rows(.id = "sheet_name") %>%
     dplyr::filter(dplyr::if_any(c("SNU1", "PSNU", "Age", "Sex"), ~!is.na(.))) %>%
     dplyr::select(sheet_name, PSNU) %>%

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -748,7 +748,8 @@ checkInvalidOrgUnits <- function(sheets, d, quiet = TRUE) {
     dplyr::bind_rows(.id = "sheet_name") %>%
     dplyr::select(sheet_name, PSNU) %>%
     dplyr::distinct() %>%
-    dplyr::mutate(psnuid = extract_uid(PSNU)) %>%
+    #dplyr::mutate(psnuid = extract_uid(PSNU)) %>%
+    dplyr::mutate(psnuid = purrr::pmap_chr(list(PSNU), extract_uid)) %>%
     dplyr::anti_join(valid_PSNUs, by = c("psnuid" = "psnu_uid"))
 
   na_orgunits <- invalid_orgunits[is.na(invalid_orgunits$PSNU), ]
@@ -806,7 +807,7 @@ checkInvalidPrioritizations <- function(sheets, d, quiet = TRUE) {
   data <- d$sheets[["Prioritization"]][, c("PSNU", "IMPATT.PRIORITY_SNU.T")]
   names(data)[names(data) == "IMPATT.PRIORITY_SNU.T"] <- "value"
   data <- data[, c("PSNU", "value")]
-  data$psnuid <- extract_uid(data$PSNU)
+  data$psnuid <- purrr::pmap_chr(list(data$PSNU), extract_uid) #extract_uid(data$PSNU)
   data <- data[data$psnuid %in% valid_PSNUs$psnu_uid, ]
   data <- data[!data$psnuid %in% valid_PSNUs$psnu_uid[valid_PSNUs$psnu_type == "Military"], ]
   invalid_prioritizations <- data[!data$value %in% prioritization_dict()$value, ]

--- a/R/unPackingChecks.R
+++ b/R/unPackingChecks.R
@@ -746,7 +746,7 @@ checkInvalidOrgUnits <- function(sheets, d, quiet = TRUE) {
 
   invalid_orgunits <<- d$sheets[sheets] %>%
     dplyr::bind_rows(.id = "sheet_name") %>%
-    filter(if_any(c("SNU1", "PSNU", "Age", "Sex"), ~!is.na(.))) %>%
+    dplyr::filter(dplyr::if_any(c("SNU1", "PSNU", "Age", "Sex"), ~!is.na(.))) %>%
     dplyr::select(sheet_name, PSNU) %>%
     dplyr::distinct() %>%
     dplyr::mutate(psnuid = extract_uid(PSNU)) %>%

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -616,7 +616,8 @@ NULL
 #' @rdname extract_uid
 #'
 extract_uid <- function(string) {
-  stringr::str_extract(string, "[[:alpha:]][[:alnum:]]{10}")
+  #stringr::str_extract(string, "[[:alpha:]][[:alnum:]]{10}")
+  gsub("\\[|]", "", tail(stringr::str_extract_all(string, "\\[(.*?)\\]")[[1]], 1))
 }
 
 #' @export

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -615,9 +615,14 @@ NULL
 #' @export
 #' @rdname extract_uid
 #'
-extract_uid <- function(string) {
-  #stringr::str_extract(string, "[[:alpha:]][[:alnum:]]{10}")
-  gsub("\\[|]", "", tail(stringr::str_extract_all(string, "\\[(.*?)\\]")[[1]], 1))
+extract_uid <- function(string, bracketed = TRUE) {
+
+  pattern <- ifelse(bracketed,
+                    "(?<=\\[)[[:alpha:]][[:alnum:]]{10}(?=\\]$)",
+                    "[[:alpha:]][[:alnum:]]{10}")
+
+  stringr::str_extract(string, pattern)
+
 }
 
 #' @export


### PR DESCRIPTION
## Developer: Fausto

### Summary of Proposed Changes
- Fix for issues referenced in DP-784
- `extract_uid` was altered to correctly parse psnuids
- blank data was removed from invalid prioritization analysis so as to not kick a false positive
- added cleaning of empty columns and rows to readSheet to avoid duplicate column false positive as well as remove unnecessary data
- corrected country uid equality test to properly allow for loading of regions like the Carribean
- tested with Namibia, South Africa, Zimbabwe, Caribbean, Angola, currently only seeing warnings, all tests pass.

### Related Issues
- DP-784


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
