### PR TITLE
Fix checkMechanisms for OPUs

### DIFF
--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -14,7 +14,7 @@ checkMechanisms <- function(d,
                                                 inherits = TRUE)) {
 
   #Do not refer to d$datim$MER or d$datim$OPU directly.
-  mechs_data <- d$data$analytics$mechanism_code
+  mechs_data <- unique(d$data$analytics$mechanism_code)
 
   stopifnot("Mechanisms cannot be null." = !is.null(mechs_data) || length(mechs_data) != 0L)
 

--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -13,7 +13,10 @@ checkMechanisms <- function(d,
                             d2_session = dynGet("d2_default_session",
                                                 inherits = TRUE)) {
 
-  mechs_data <- unique(d$datim$MER$attributeOptionCombo)
+  #Do not refer to d$datim$MER or d$datim$OPU directly.
+  mechs_data <- d$data$analytics$mechanism_code
+
+  stopifnot("Mechanisms cannot be null." = !is.null(mechs_data) || length(mechs_data) != 0L)
 
   period_info <- datimvalidation::getPeriodFromISO(paste0(d$info$cop_year, "Oct"))
 

--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -34,8 +34,8 @@ checkMechanisms <- function(d,
   #Allow for the default mechanism
   mechs_datim <- append("HllvX50cXC0", mechs_datim)
 
-  #Allow for the dedupe mechanisms in COP21 Data packs
-  if (d$info$tool == "Data Pack" && d$info$cop_year %in% c(2021, 2022)) {
+  #Allow for the dedupe mechanisms in COP21/COP22 DataPacks and OPUs
+  if (d$info$tool %in% c("Data Pack","OPU Data Pack") && d$info$cop_year %in% c(2021, 2022)) {
     mechs_datim <- append(c("00000", "00001"), mechs_datim)
   }
 

--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -32,14 +32,14 @@ checkMechanisms <- function(d,
     dplyr::pull(mechanism_code)
 
   #Allow for the default mechanism
-  mechs_datim <- append("HllvX50cXC0", mechs_datim)
+  mechs_datim <- append("default", mechs_datim)
 
   #Allow for the dedupe mechanisms in COP21/COP22 DataPacks and OPUs
   if (d$info$tool %in% c("Data Pack", "OPU Data Pack") && d$info$cop_year %in% c(2021, 2022)) {
     mechs_datim <- append(c("00000", "00001"), mechs_datim)
   }
 
-  bad_mechs <- mechs_data[!(mechs_data %in% c(mechs_datim, "default"))]
+  bad_mechs <- mechs_data[!(mechs_data %in% mechs_datim)]
 
   if (length(bad_mechs) > 0) {
     msg <- paste0("ERROR!: Invalid mechanisms found in the PSNUxIM tab.

--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -35,7 +35,7 @@ checkMechanisms <- function(d,
   mechs_datim <- append("HllvX50cXC0", mechs_datim)
 
   #Allow for the dedupe mechanisms in COP21/COP22 DataPacks and OPUs
-  if (d$info$tool %in% c("Data Pack","OPU Data Pack") && d$info$cop_year %in% c(2021, 2022)) {
+  if (d$info$tool %in% c("Data Pack", "OPU Data Pack") && d$info$cop_year %in% c(2021, 2022)) {
     mechs_datim <- append(c("00000", "00001"), mechs_datim)
   }
 

--- a/R/checkMechanisms.R
+++ b/R/checkMechanisms.R
@@ -39,7 +39,7 @@ checkMechanisms <- function(d,
     mechs_datim <- append(c("00000", "00001"), mechs_datim)
   }
 
-  bad_mechs <- mechs_data[!(mechs_data %in% mechs_datim)]
+  bad_mechs <- mechs_data[!(mechs_data %in% c(mechs_datim, "default"))]
 
   if (length(bad_mechs) > 0) {
     msg <- paste0("ERROR!: Invalid mechanisms found in the PSNUxIM tab.

--- a/R/unPackDataPack.R
+++ b/R/unPackDataPack.R
@@ -69,10 +69,10 @@ unPackDataPack <- function(d,
   interactive_print("Creating analytics...")
   d <- createAnalytics(d, d2_session = d2_session)
 
+  d <- checkNotPEPFARSupportedPSNUs(d)
+
   # Check for invalid mechanisms
   d <- checkMechanisms(d, d2_session = d2_session)
-
-  d <- checkNotPEPFARSupportedPSNUs(d)
 
   return(d)
 

--- a/R/unPackDataPack.R
+++ b/R/unPackDataPack.R
@@ -69,6 +69,9 @@ unPackDataPack <- function(d,
   interactive_print("Creating analytics...")
   d <- createAnalytics(d, d2_session = d2_session)
 
+  # Check for invalid mechanisms
+  d <- checkMechanisms(d, d2_session = d2_session)
+
   d <- checkNotPEPFARSupportedPSNUs(d)
 
   return(d)

--- a/R/unPackOPUDataPack.R
+++ b/R/unPackOPUDataPack.R
@@ -37,6 +37,9 @@ unPackOPUDataPack <- function(d,
   # Prepare data for sharing with other systems ####
   d <- createAnalytics(d, d2_session = d2_session)
 
+  # Check for invalid mechanisms
+  d <- checkMechanisms(d, d2_session = d2_session)
+
   return(d)
 
 }

--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -391,7 +391,8 @@ unPackSNUxIM <- function(d) {
     tibble::tibble(col_name = .) %>%
     dplyr::filter(!col_name %in% cols_to_keep$indicator_code,
                   !(stringr::str_detect(col_name, "(\\d){4,6}")
-                    & stringr::str_detect(col_name, "DSD|TA")))
+                    & stringr::str_detect(col_name, "DSD|TA"))) %>%
+    dplyr::filter(col_name != "Not PEPFAR") #Specifically allow for "Not PEPFAR"
   # nolint end
 
   #Test specifically for DSD and TA which have been populated as mechanisms by the user.

--- a/tests/testthat/test-checkMechanisms.R
+++ b/tests/testthat/test-checkMechanisms.R
@@ -10,7 +10,7 @@ with_mock_api({
     d$info$tool <- "Data Pack"
     d$info$messages <- MessageQueue()
     d$tests <- list()
-    d$datim$MER <- data.frame(attributeOptionCombo = c("100000", "10432"))
+    d$data$analytics <- data.frame(mechanism_code = c("100000", "10432"))
     d <- checkMechanisms(d, d2_session = training)
     expect_true(d$info$has_error)
     expect_true(!is.null(d$tests$bad_mechs))


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->

- Adjusts source of mechanisms to d$data$analytics. Mechanism checks were being ignored for OPUs, since there was a reference to d$datim$MER, which does not exist for OPUs. 
-  Allows for dedupe mechanisms in COP21 OPUs
-  Allows for "Not PEPFAR" column in the PSNUxIM tab.

### Related Issues
- DP-XXX
- etc.

<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
