### PR TITLE
bug: Duplication of indicators in the memo

### DIFF
--- a/R/getMechanismView.R
+++ b/R/getMechanismView.R
@@ -71,15 +71,7 @@ getMechanismView <- function(country_uids = NULL,
 
   if (!is_fresh) {
     interactive_print("Fetching new mechs file from DATIM")
-
-    mechs <- if (is.null(cop_year)) {
-      datimutils::getSqlView(sql_view_uid = "fgUtV6e9YIX", d2_session = d2_session)
-    } else {
-      url_filter <- c(paste0("startdate:lt:", as.numeric(cop_year) + 1, "-10-01"),
-                      paste0("enddate:gt:", cop_year, "-09-30"))
-
-      datimutils::getSqlView(url_filter, sql_view_uid = "fgUtV6e9YIX", d2_session = d2_session)
-    }
+    mechs <- datimutils::getSqlView(sql_view_uid = "fgUtV6e9YIX", d2_session = d2_session)
 
     mechs <- mechs %>%
       dplyr::rename(
@@ -92,11 +84,38 @@ getMechanismView <- function(country_uids = NULL,
     if (can_write_file) {
       interactive_print(paste0("Overwriting stale mechanisms view to ", cached_mechs_path))
       saveRDS(mechs, file = cached_mechs_path)
-    }
-  }
+      }
+}
+
+
+#Keep these separate if we need them after other filtering
+dedupe_mechs <- mechs %>%
+  dplyr::filter(mechanism_code %in% c("00000", "00001"))
+
+moh_mechs <- mechs %>%
+  dplyr::filter(mechanism_code %in% c("00100", "00200"))
+
+
+
+# Filter by COP Year ####
+if (!is.null(cop_year)) {
+
+  cop_year %<>% check_cop_year(cop_year = cop_year)
+
+  mechs %<>%
+    dplyr::filter(
+      (startdate < paste0(max(as.numeric(cop_year)) + 1, "-10-01") &
+         enddate > paste0(min(as.numeric(cop_year)), "-09-30")))
+}
+
+
 
   # Filter by OU from a vector of country UIDs
   if (!is.null(country_uids)) {
+
+    cop_year <- cop_year %missing% NULL
+    cop_year %<>% check_cop_year(cop_year = cop_year)
+
     ous <- getValidOrgUnits(cop_year) %>%
       dplyr::select(ou, ou_uid, country_uid) %>%
       dplyr::distinct() %>%
@@ -105,29 +124,17 @@ getMechanismView <- function(country_uids = NULL,
       unique(.)
 
     mechs %<>%
-      dplyr::filter(ou %in% ous | is.na(ou))
+      dplyr::filter(ou %in% ous)
   }
 
-  # Filter by COP Year ####
-  if (!is.null(cop_year)) {
-    mechs %<>%
-        dplyr::filter(
-          (startdate < paste0(max(as.numeric(cop_year)) + 1, "-10-01") &
-            enddate > paste0(min(as.numeric(cop_year)), "-09-30"))
-          | is.na(startdate))
-  }
 
   # Include Dedupe or MOH ####
-  if (!include_MOH) {
-    MOH <- c("QCJpv5aDCJU", "TRX0yuTsJA9")
-    mechs %<>%
-      dplyr::filter(!attributeOptionCombo %in% MOH)
+  if (include_MOH) {
+    mechs <- dplyr::bind_rows(mechs, moh_mechs)
   }
 
-  if (!include_dedupe) {
-    dedupe <- c("X8hrDf6bLDC", "YGT1o7UxfFu")
-    mechs %<>%
-      dplyr::filter(!attributeOptionCombo %in% dedupe)
+  if (include_dedupe) {
+    mechs <-  dplyr::bind_rows(mechs, dedupe_mechs)
   }
 
   if (include_default) {
@@ -139,17 +146,25 @@ getMechanismView <- function(country_uids = NULL,
       partner_desc = "None",
       partner_id = "None",
       agency = "None",
-      ou = NA,
-      startdate = NA,
-      enddate = NA
+      ou = "",
+      startdate = "",
+      enddate = ""
     )
 
-    mechs <- rbind(mechs, default_mech)
+    mechs <- dplyr::bind_rows(mechs, default_mech)
   }
 
   structure_ok <- dplyr::setequal(names(empty_mechs_view), names(mechs))
 
+  if (any(duplicated(mechs$mechanism_code))) {
+    stop("Duplicated mechanisms codes detected¸")
+  }
+
   if (!structure_ok) warning("Mechanism view names are not correct!")
+
+  if (NROW(mechs) == 0) {
+    warning("No mechanisms for the combination of paramaters were found")
+  }
 
   return(mechs)
 

--- a/tests/testthat/test-getMechanismView.R
+++ b/tests/testthat/test-getMechanismView.R
@@ -1,27 +1,50 @@
 
-context("Get a mechanism view when logged into DATIM")
+context("Get a mechanism view")
 
   with_mock_api({
-    # This part works.
-    test_that("We can get a mechanism list when logged in", {
-      test_mech_list <- datimutils::getSqlView(sql_view_uid = "fgUtV6e9YIX",
-                                               d2_session = training)
 
-      expect_type(test_mech_list, "list")
+    test_that("We can get a mechanism list ", {
+      mechs <- getMechanismView(d2_session = training)
+      expect_named(mechs, c("mechanism_desc",
+                           "mechanism_code",
+                           "attributeOptionCombo",
+                           "partner_desc",
+                           "partner_id", "agency", "ou", "startdate", "enddate"))
 
-      mechs_names <- c("mechanism",
-                     "code",
-                     "uid",
-                     "partner",
-                     "primeid",
-                     "agency",
-                     "ou",
-                     "startdate",
-                     "enddate")
+      expect_true(NROW(mechs) > 0)
 
-      expect_true(setequal(mechs_names, names(test_mech_list)))
+      expect_false(any(duplicated(mechs$mechanism_desc)))
+      expect_false(any(duplicated(mechs$mechanism_code)))
+      expect_false(any(duplicated(mechs$attributeOptionCombo)))
+      expect_true(all(is_uidish(mechs$attributeOptionCombo)))
 
-      #Expect error on a faulty dataset UID
-      expect_error(datimutils::getSqlView("foo"))
+
+      #Zambia mechs only
+      expect_identical("Zambia", unique(getMechanismView(country_uids = "f5RoebaDLMx",
+                                                        include_dedupe = FALSE,
+                                                        include_default = FALSE,
+                                                        include_MOH = FALSE,
+                                                        d2_session = training)$ou))
+
+      #Should not include dedupe
+      expect_identical(0L, sum(getMechanismView(country_uids = "f5RoebaDLMx",
+                                                include_dedupe = FALSE,
+                                                include_default = FALSE,
+                                                include_MOH = FALSE,
+                                                d2_session = training)$mechanism_code %in% c("00000", "00001")))
+
+      #Should include dedupe
+      expect_identical(2L, sum(getMechanismView(country_uids = "f5RoebaDLMx",
+                                                        include_dedupe = TRUE,
+                                                        include_default = FALSE,
+                                                        include_MOH = FALSE,
+                                                        d2_session = training)$mechanism_code %in% c("00000", "00001")))
+
+      #Bogus country UIDS with no defaults produces no rows
+      expect_warning(getMechanismView(country_uids = "abcdef12345",
+                                      include_default = FALSE,
+                                      d2_session = training))
+      #Bogus cop year gives an error
+      expect_error(getMechanismView(cop_year = 1999, d2_session = training))
     })
   })


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->
- There were various problems with the generation of the memo indicators. Certain values were being duplicated under certain circumstances. 
- Client side filtering was being handled too early, resulting in dedupe not being carried through. This has been reworked.
- Added additional tests.

### Related Issues
- DP-889


<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
