### PR TITLE
Modify dedpue handling in OPU compare

### DIFF
--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -306,7 +306,7 @@ compareData_OpuDatapackVsDatim <-
       dplyr::rename(value = datim_value)
 
 # cases in which datapack has a new orupdated value
-    updates <- dplyr::filter(data_differences, !is.na(datapack_value))%>%
+    updates <- dplyr::filter(data_differences, !is.na(datapack_value)) %>%
       dplyr::filter(!(attributeOptionCombo %in%
                         c("00000", "00001"))) %>%
       dplyr::select(-datim_value) %>%

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -298,9 +298,7 @@ compareData_OpuDatapackVsDatim <-
     data_differences <- dplyr::full_join(datapack_data, datim_data) %>%
       dplyr::filter(datapack_value != datim_value |
                       is.na(datapack_value) |
-                      is.na(datim_value)) %>%
-      dplyr::filter(!(attributeOptionCombo %in%
-                      c("00000", "00001")))
+                      is.na(datim_value))
 
 # cases in which datim has a value but datapack does not
     deletes <- dplyr::filter(data_differences, is.na(datapack_value)) %>%
@@ -308,7 +306,9 @@ compareData_OpuDatapackVsDatim <-
       dplyr::rename(value = datim_value)
 
 # cases in which datapack has a new orupdated value
-    updates <- dplyr::filter(data_differences, !is.na(datapack_value)) %>%
+    updates <- dplyr::filter(data_differences, !is.na(datapack_value))%>%
+      dplyr::filter(!(attributeOptionCombo %in%
+                        c("00000", "00001"))) %>%
       dplyr::select(-datim_value) %>%
       dplyr::rename(value = datapack_value)
 

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -307,8 +307,6 @@ compareData_OpuDatapackVsDatim <-
 
 # cases in which datapack has a new orupdated value
     updates <- dplyr::filter(data_differences, !is.na(datapack_value)) %>%
-      dplyr::filter(!(attributeOptionCombo %in%
-                        c("00000", "00001"))) %>%
       dplyr::select(-datim_value) %>%
       dplyr::rename(value = datapack_value)
 


### PR DESCRIPTION
Modify to include mismatched dedupes in the deletion data frame but exclude from the updates data frame. All dedupes for import are included in the dedupes data frame

## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->

### Related Issues
- DP-XXX
- etc.

<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
