### PR TITLE
Fix bug when checkingAnalytics with only PSNUxIM tools

### DIFF
--- a/R/extractRawColumnData.R
+++ b/R/extractRawColumnData.R
@@ -14,7 +14,8 @@
 extractRawColumnData <- function(d, sheet, cols) {
 
   if (is.null(sheet) || !(sheet %in% names(d$sheets))) {
-    stop(paste("That sheet could not be found: ", sheet))
+    warning(paste("That sheet could not be found: ", sheet))
+    return(NULL)
   }
 
   if (!("PSNU" %in% cols)) {


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->

- checkAnalytics (and the app) will fail if users run ONLY a PSNUxIM tool through the app due to missing required sheets. This situation does not happen with a TST+PSNU combo, but better to fix it just in case. 

### Related Issues


<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
