### PR TITLE
Fix issue with blank DP targets in unPackSNUxIM

### DIFF
--- a/R/unPackSNUxIM.R
+++ b/R/unPackSNUxIM.R
@@ -222,12 +222,11 @@ checkNonEqualTargets <- function(d, original_targets) {
       #If the main tab value is missing and the DataPackTarget is zero, ignore
       dplyr::mutate(are_equal = dplyr::case_when(is.na(MainTabsTarget) & DataPackTarget == 0 ~ TRUE,
                                                  is.na(MainTabsTarget) & DataPackTarget != 0 ~ FALSE,
+                                                 !is.na(MainTabsTarget) & is.na(DataPackTarget) ~ FALSE,
                                                  TRUE ~ are_equal)) %>%
       dplyr::filter(!are_equal | is.na(are_equal)) %>%
-      #Filter non-allocated data to prevent false positives with this test
-      #Other tests should catch whether there is data in the main tabs
-      #but which has not been allocated
-      dplyr::filter(!is.na(DataPackTarget)) %>%
+      #Filter instances where both the DP and PSNUxIM Target are NA
+      dplyr::filter(!(is.na(DataPackTarget) & is.na(MainTabsTarget))) %>%
       dplyr::rename("PSNUxIM Target" = DataPackTarget)
 
     attr(d$tests$non_equal_targets, "test_name") <- "Non-equal targets"


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->

- When values in the PSNUxIM tab were blank (but not in the main tabs), these rows were not being properly flagged by the non-equal test code. 

### Related Issues
- DP-1041
- etc.

<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
