### PR TITLE
Dp 1003 sam

### DIFF
--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -137,7 +137,7 @@ compareData_DatapackVsDatim <-
     datapack_data_psnu_x_im <- datapack_data
 
 # Get data from DATIM using data value sets
-    if (is.null(datim_data)){
+    if (is.null(datim_data)) {
       if (d$info$cop_year == 2022 &&
           "subnat_targets" %in% datastreams) {
         datim_data <- dplyr::bind_rows(
@@ -161,7 +161,7 @@ compareData_DatapackVsDatim <-
 
     if (!is.null(datim_data)) {
       datim_data %<>% dplyr::rename(datim_value = value)
-      if(d$info$tool == "OPU Data Pack"){
+      if (d$info$tool == "OPU Data Pack") {
 ### data in OPU datapacks must have a valid Mech or dedupe mech
 ### so we do not compare dreams or any other data without mech
         datim_data <- dplyr::filter(datim_data,

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -76,6 +76,7 @@ compareData_DatapackVsDatim <-
       stop("Attempting to use compareData_DatapackVsDatim for unsupported COP year")
     }
 
+# filter to data elements in the stream specified
     included_data_elements <- getMapDataPack_DATIM_DEs_COCs(d$info$cop_year) %>%
       dplyr::select(dataelementuid, dataset) %>%
       dplyr::distinct() %>%
@@ -127,14 +128,16 @@ compareData_DatapackVsDatim <-
                                           dataElement,
                                           orgUnit,
                                           categoryOptionCombo) %>%
-      dplyr::summarise(datapack_value = sum(datapack_value, na.rm = TRUE), .groups = "drop")
+      dplyr::summarise(datapack_value = sum(datapack_value, na.rm = TRUE),
+                       .groups = "drop")
 
     datapack_data_psnu_x_im <- datapack_data
 
 # Get data from DATIM using data value sets
     if (is.null(datim_data)) {
       if (d$info$cop_year == 2022 &&
-          "subnat_targets" %in% datastreams) {
+          "subnat_targets" %in% datastreams &&
+          d$info$tool = "Data Pack") { # Get last year's subnat targets too
         datim_data <- dplyr::bind_rows(
           getCOPDataFromDATIM(country_uids = d$info$country_uids,
                               cop_year = d$info$cop_year,
@@ -176,7 +179,8 @@ compareData_DatapackVsDatim <-
                       dataElement,
                       orgUnit,
                       categoryOptionCombo) %>%
-      dplyr::summarise(datim_value = sum(datim_value), .groups = "drop")
+      dplyr::summarise(datim_value = sum(datim_value),
+                       .groups = "drop")
 
 # get rid of dedups in the data dissagregated by IM
     datim_data_psnu_x_im <- datim_data
@@ -188,8 +192,6 @@ compareData_DatapackVsDatim <-
     data_psnu_x_im <-
       dplyr::full_join(datim_data_psnu_x_im,
                        datapack_data_psnu_x_im)
-
-
 
 # Find the cases with different values. These should be  imported into DATIM
     data_different_value <-

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -137,7 +137,7 @@ compareData_DatapackVsDatim <-
     if (is.null(datim_data)) {
       if (d$info$cop_year == 2022 &&
           "subnat_targets" %in% datastreams &&
-          d$info$tool = "Data Pack") { # Get last year's subnat targets too
+          d$info$tool == "Data Pack") { # Get last year's subnat targets too
         datim_data <- dplyr::bind_rows(
           getCOPDataFromDATIM(country_uids = d$info$country_uids,
                               cop_year = d$info$cop_year,

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -3,53 +3,53 @@
 .compare_beautify <-  function(data,
                                cop_year,
                                d2_session = dynGet("d2_default_session",
-                                                                    inherits = TRUE)) {
-    data$data_element <-
-      datimvalidation::remapDEs(data$dataElement,
-                                mode_in = "id",
-                                mode_out = "shortName",
-                                d2session = d2_session)
+                                                   inherits = TRUE)) {
+  data$data_element <-
+    datimvalidation::remapDEs(data$dataElement,
+                              mode_in = "id",
+                              mode_out = "shortName",
+                              d2session = d2_session)
 
-    data$disagg <-
-      datimvalidation::remapCategoryOptionCombos(data$categoryOptionCombo,
-                                                 mode_in = "id",
-                                                 mode_out = "name",
-                                                 d2session = d2_session)
+  data$disagg <-
+    datimvalidation::remapCategoryOptionCombos(data$categoryOptionCombo,
+                                               mode_in = "id",
+                                               mode_out = "name",
+                                               d2session = d2_session)
 
-    psnus <-
-      getValidOrgUnits(cop_year) %>% dplyr::select(psnu = name, psnu_uid = uid)
+  psnus <-
+    getValidOrgUnits(cop_year) %>% dplyr::select(psnu = name, psnu_uid = uid)
 
-    # calculate diff between data pack and datim handling NAs like a 0
-    # round diff to 5 decimal places so we don't get differences due to floating point error
-    # add column summarizing the difference
+# calculate diff between data pack and datim handling NAs like a 0
+# round diff to 5 decimal places so we don't get differences due to floating point error
+# add column summarizing the difference
 
-    data %>%
-      dplyr::left_join(psnus, by = c("orgUnit" = "psnu_uid")) %>%
-      dplyr::mutate(
-        difference = dplyr::case_when(
-          is.na(datapack_value) ~ -datim_value,
-          is.na(datim_value) ~ datapack_value,
-          TRUE ~ round(as.numeric(datapack_value) - datim_value, 5)
-        )
-      ) %>%
-      dplyr::mutate(
-        effect = dplyr::case_when(
-          is.na(datapack_value) ~ "Delete",
-            is.na(datim_value) ~ "Create",
-           abs(difference) < 1e-5 ~ "Update",
-          abs(difference) >= 1e-5 ~ "No Change"
-        )
-      ) %>%
-     dplyr::select(tidyselect::any_of(c(
-        "psnu",
-        "data_element",
-        "disagg",
-        "attributeOptionCombo",
-        "datapack_value",
-        "datim_value",
-        "difference",
-        "effect"
-      )))
+  data %>%
+    dplyr::left_join(psnus, by = c("orgUnit" = "psnu_uid")) %>%
+    dplyr::mutate(
+      difference = dplyr::case_when(
+        is.na(datapack_value) ~ -datim_value,
+        is.na(datim_value) ~ datapack_value,
+        TRUE ~ round(as.numeric(datapack_value) - datim_value, 5)
+      )
+    ) %>%
+    dplyr::mutate(
+      effect = dplyr::case_when(
+        is.na(datapack_value) ~ "Delete",
+        is.na(datim_value) ~ "Create",
+        abs(difference) < 1e-5 ~ "Update",
+        abs(difference) >= 1e-5 ~ "No Change"
+      )
+    ) %>%
+    dplyr::select(tidyselect::any_of(c(
+      "psnu",
+      "data_element",
+      "disagg",
+      "attributeOptionCombo",
+      "datapack_value",
+      "datim_value",
+      "difference",
+      "effect"
+    )))
 }
 
 
@@ -96,11 +96,11 @@ compareData_DatapackVsDatim <-
 # recoding to account for code change in DATIM for the default COC
 # if all other code is updated to use uids instead of codes this can be removed
     datapack_data$categoryOptionCombo[datapack_data$categoryOptionCombo ==
-                                      "HllvX50cXC0"] <- "default"
+                                        "HllvX50cXC0"] <- "default"
     datapack_data$attributeOptionCombo[datapack_data$attributeOptionCombo ==
-                                       "HllvX50cXC0"] <- "default"
+                                         "HllvX50cXC0"] <- "default"
 
-    # ensure datapack_data has the expected columns
+# ensure datapack_data has the expected columns
     if (!setequal(
       names(datapack_data),
       c(
@@ -115,12 +115,12 @@ compareData_DatapackVsDatim <-
       stop("The column names of your data aren't as expected by compareData_DatapackVsDatim.")
     }
 
-    # extract dedupes from import file to handle separately
+# extract dedupes from import file to handle separately
     dedupes <-  dplyr::filter(datapack_data,
-                             attributeOptionCombo %in%
-                               c("00000", "00001"))
+                              attributeOptionCombo %in%
+                                c("00000", "00001"))
 
-    # rename columns to fit standards
+# rename columns to fit standards
     datapack_data <- datapack_data %>%
       dplyr::rename(
         datapack_value = value) %>%
@@ -139,43 +139,43 @@ compareData_DatapackVsDatim <-
 # Get data from DATIM using data value sets
     if (is.null(datim_data)){
       if (d$info$cop_year == 2022 &&
-               "subnat_targets" %in% datastreams) {
-      datim_data <- dplyr::bind_rows(
-      getCOPDataFromDATIM(country_uids = d$info$country_uids,
-                          cop_year = d$info$cop_year,
-                          datastreams = datastreams,
-                          d2_session = d2_session),
-      getCOPDataFromDATIM(country_uids = d$info$country_uids,
-                          cop_year = d$info$cop_year - 1,
-                          datastreams = c("subnat_targets"),
-                          d2_session = d2_session))
+          "subnat_targets" %in% datastreams) {
+        datim_data <- dplyr::bind_rows(
+          getCOPDataFromDATIM(country_uids = d$info$country_uids,
+                              cop_year = d$info$cop_year,
+                              datastreams = datastreams,
+                              d2_session = d2_session),
+          getCOPDataFromDATIM(country_uids = d$info$country_uids,
+                              cop_year = d$info$cop_year - 1,
+                              datastreams = c("subnat_targets"),
+                              d2_session = d2_session))
       } else {
-      datim_data <-
-        getCOPDataFromDATIM(country_uids = d$info$country_uids,
-                        cop_year = d$info$cop_year,
-                        datastreams = datastreams,
-                        d2_session = d2_session)
+        datim_data <-
+          getCOPDataFromDATIM(country_uids = d$info$country_uids,
+                              cop_year = d$info$cop_year,
+                              datastreams = datastreams,
+                              d2_session = d2_session)
       }
-      }
+    }
 
 
-      if (!is.null(datim_data)) {
-        datim_data %<>% dplyr::rename(datim_value = value)
-        if(d$info$tool == "OPU Data Pack"){
-          ### data in OPUU datapacks muust have a valid Mech or dedupe
-          ### so we do not compare dreams or any other data without mech
-          datim_data <- dplyr::filter(datim_data,
-                                      attributeOptionCombo != "default")
-        }
+    if (!is.null(datim_data)) {
+      datim_data %<>% dplyr::rename(datim_value = value)
+      if(d$info$tool == "OPU Data Pack"){
+### data in OPU datapacks must have a valid Mech or dedupe mech
+### so we do not compare dreams or any other data without mech
+        datim_data <- dplyr::filter(datim_data,
+                                    attributeOptionCombo != "default")
       }
+    }
 
-  #There might not be any data in DAITM
-      if (is.null(datim_data)) {
-        datim_data <- datapack_data_psnu_x_im %>%
-          dplyr::mutate(datim_value = NA_real_) %>%
-          dplyr::select(-datapack_value)
-      }
-    # Sum over IM including dedup
+#There might not be any data in DAITM
+    if (is.null(datim_data)) {
+      datim_data <- datapack_data_psnu_x_im %>%
+        dplyr::mutate(datim_value = NA_real_) %>%
+        dplyr::select(-datapack_value)
+    }
+# Sum over IM including dedup
     datim_data_psnu <-
       dplyr::group_by(datim_data,
                       dataElement,
@@ -183,10 +183,10 @@ compareData_DatapackVsDatim <-
                       categoryOptionCombo) %>%
       dplyr::summarise(datim_value = sum(datim_value), .groups = "drop")
 
-    # get rid of dedups in the data dissagregated by IM
+# get rid of dedups in the data dissagregated by IM
     datim_data_psnu_x_im <- datim_data
 
-    # join the data pack data and the datim data
+# join the data pack data and the datim data
     data_psnu <- dplyr::full_join(datim_data_psnu,
                                   datapack_data_psnu)
 
@@ -200,7 +200,7 @@ compareData_DatapackVsDatim <-
     data_different_value <-
       dplyr::filter(
         data_psnu_x_im,
-         !dplyr::near(datim_value, datapack_value, 1e-5) | is.na(datim_value)
+        !dplyr::near(datim_value, datapack_value, 1e-5) | is.na(datim_value)
       ) %>%
       dplyr::select(
         dataElement,
@@ -211,7 +211,7 @@ compareData_DatapackVsDatim <-
         value = datapack_value
       )
 
-    # data in datim but not in the data pack
+# data in datim but not in the data pack
     data_datim_only <-
       dplyr::filter(data_psnu_x_im,
                     is.na(datapack_value)) %>%

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -216,7 +216,7 @@ compareData_DatapackVsDatim <-
         orgUnit,
         categoryOptionCombo,
         attributeOptionCombo,
-        valuue = datim_value
+        value = datim_value
       )
 
     data_psnu_x_im %<>% .compare_beautify(cop_year = d$info$cop_year,

--- a/R/datapackVsDatim.R
+++ b/R/datapackVsDatim.R
@@ -115,11 +115,6 @@ compareData_DatapackVsDatim <-
       stop("The column names of your data aren't as expected by compareData_DatapackVsDatim.")
     }
 
-# extract dedupes from import file to handle separately
-    dedupes <-  dplyr::filter(datapack_data,
-                              attributeOptionCombo %in%
-                                c("00000", "00001"))
-
 # rename columns to fit standards
     datapack_data <- datapack_data %>%
       dplyr::rename(
@@ -234,8 +229,7 @@ compareData_DatapackVsDatim <-
       psnu_x_im = data_psnu_x_im,
       psnu = data_psnu,
       updates = data_different_value,
-      deletes = data_datim_only,
-      dedupes = dedupes
+      deletes = data_datim_only
     )
   }
 

--- a/tests/testthat/test-compareDataPackvsDATIM.R
+++ b/tests/testthat/test-compareDataPackvsDATIM.R
@@ -24,7 +24,7 @@ with_mock_api({
 
     compare <- compareData_DatapackVsDatim(d, d2_session = training)
 
-    expect_named(compare, c("psnu_x_im", "psnu", "updates", "deletes", "dedupes"))
+    expect_named(compare, c("psnu_x_im", "psnu", "updates", "deletes"))
 
     diff_names <- c(
       "psnu",
@@ -80,7 +80,7 @@ with_mock_api({
       compare$updates$categoryOptionCombo == "default"))
     #Since this is undistributed data, we should only be dealing with the default mechanism
     expect_true(all(compare$updates$attributeOptionCombo  == "default"))
-    expect_true(inherits(compare$updates$datapack_value, "numeric"))
+    expect_true(inherits(compare$updates$value, "numeric"))
 
     # skip("Remove this after merging with DP-901")
     # #For COP23, there should only be 2023Oct data


### PR DESCRIPTION
### Summary of Proposed Changes

Modifies and streamlines datapack to DATIM comparison ahead of cop23 OPU processing.

- Better respect for the data streams parameter
- Stop returning dedupe data from the datapack as it isn't really related to comparing data, rather it is a holdover from the opu datapack comparison that used to return all the import files.
- remove code the filters out dreams data from OPU datapack. This is unnecesary as it is not possible for dreams data to be in a psnuXim only OPU datapack  

### Related Issues
- DP-1003
- Note there is a related PR label DP-1003 in the data-pack repo. These should be released at the same time. https://github.com/pepfar-datim/Data-Pack/pull/1167

## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
