### PR TITLE
Added exclusion of COP24 for regions

### DIFF
--- a/R/check_params.R
+++ b/R/check_params.R
@@ -473,9 +473,9 @@ checkDataPackName <- function(datapack_name, country_uids, cop_year) {
                          "oK0gC85xx2f")
 
     # Thu Nov 30 13:59:22 2023 added the 2024 to address country's being broken out.
-    if (all(country_uids %in% caribbean) && cop_year !=2024) {
+    if (all(country_uids %in% caribbean) && cop_year != 2024) {
       expected_dpname <- "Caribbean Region"
-    } else if (all(country_uids %in% central_america) && cop_year !=2024) {
+    } else if (all(country_uids %in% central_america) && cop_year != 2024) {
       expected_dpname <- "Central America and Brazil"
     } else {
       expected_dpname <- valid_orgunits_local %>%

--- a/R/check_params.R
+++ b/R/check_params.R
@@ -472,9 +472,10 @@ checkDataPackName <- function(datapack_name, country_uids, cop_year) {
                          "EXVC4bNtv84", "w5NMe34EjPN", "aUTsSmqqu9O",
                          "oK0gC85xx2f")
 
-    if (all(country_uids %in% caribbean)) {
+    # Thu Nov 30 13:59:22 2023 added the 2024 to address country's being broken out.
+    if (all(country_uids %in% caribbean) && cop_year !=2024) {
       expected_dpname <- "Caribbean Region"
-    } else if (all(country_uids %in% central_america)) {
+    } else if (all(country_uids %in% central_america) && cop_year !=2024) {
       expected_dpname <- "Central America and Brazil"
     } else {
       expected_dpname <- valid_orgunits_local %>%


### PR DESCRIPTION

### Summary of Proposed Changes
- Brazil and Jamaica were not producible datapacks due to being considered part of the Central American and Caribbean regions, we added an exclusion ifelse for cop24 in checkDataPackName

### Related Issues
- DP-1177


## Reviewer:
- [ ] Tests added/updated & passing.
- [ ] Clean linting.
- [ ] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [ ] Code conforms to style guidelines.
- [ ] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
