### PR TITLE
Fix package checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: datapackr
 Title: A Package that Packs and Unpacks all Data Packs and Target Setting
     Tools
-Version: 7.4.1
-Date: 2024-03-15
+Version: 7.4.2
+Date: 2024-04-05
 Authors@R: c(
     person("Scott", "Jackson", , "sjackson@baosystems.com", role = c("aut", "cre")),
     person("Jason", "Pickering", , "jason.p.pickering@gmail.com", role = c("aut", "rev")),

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -45,14 +45,13 @@ getRDA <- function(object_name) {
     return(paste0("/root/project/data/", object_name, ".rda"))
   }
 
- foo <- tryCatch({
+ rda_location <- tryCatch({
     return(rprojroot::find_package_root_file("data", paste0(object_name, ".rda")))
   }, error = function(e) {
     return(system.file("data", paste0(object_name, ".rda"), package = "datapackr"))
   })
 
- cat(foo)
- return(foo)
+ return(rda_location)
 
 }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -29,18 +29,13 @@ getTemplate <- function(path) {
     return(paste0("/root/project/inst/extdata/", path))
   }
 
+  location <- system.file("extdata", path, package = "datapackr")
 
-  first <- rprojroot::find_package_root_file("inst/extdata", path)
-  second <- rprojroot::find_package_root_file("extdata", path)
-
-  if (file.exists(first)) {
-    return(first)
-  } else if (file.exists(second)) {
-    return(second)
+if (file.exists(location)) {
+    return(location)
   } else {
     stop("No template could be found")
   }
-
 
 }
 
@@ -50,15 +45,15 @@ getRDA <- function(object_name) {
     return(paste0("/root/project/data/", object_name, ".rda"))
   }
 
-  first <- rprojroot::find_package_root_file("data", paste0(object_name, ".rda"))
-  second <- paste0(getwd(), "/", object_name, ".rda")
-  if (file.exists(first)) {
-    return(first)
-  } else if (file.exists(second)) {
-    return(second)
-  } else {
-    stop("No template could be found")
-  }
+ foo <- tryCatch({
+    return(rprojroot::find_package_root_file("data", paste0(object_name, ".rda")))
+  }, error = function(e) {
+    return(system.file("data", paste0(object_name, ".rda"), package = "datapackr"))
+  })
+
+ cat(foo)
+ return(foo)
+
 }
 
 # login object stubs sufficient for use in mocked api calls

--- a/tests/testthat/test-create-schema.R
+++ b/tests/testthat/test-create-schema.R
@@ -173,7 +173,7 @@ with_mock_api({
     expect_type(test_dataset$formula, "character")
     expect_type(test_dataset$FY, "double")
     expect_type(test_dataset$period, "character")
-    load(getRDA("cop22_data_pack_schema"))
+    #load(getRDA("cop22_data_pack_schema"))
     expect_identical(test_dataset, cop22_data_pack_schema)
     # Seems to no longer work with list columns
 
@@ -232,11 +232,9 @@ with_mock_api({
     expect_type(test_dataset$formula, "character")
     expect_type(test_dataset$FY, "double")
     expect_type(test_dataset$period, "character")
-    load(getRDA("cop23_data_pack_schema"))
+    #load(getRDA("cop23_data_pack_schema"))
     expect_identical(test_dataset, cop23_data_pack_schema)
     # Seems to no longer work with list columns
-
-
   })
 
 })
@@ -292,7 +290,7 @@ with_mock_api({
     expect_type(test_dataset$formula, "character")
     expect_type(test_dataset$FY, "double")
     expect_type(test_dataset$period, "character")
-    load(getRDA("cop23_data_pack_schema"))
+    #load(getRDA("cop23_data_pack_schema"))
     expect_false(identical(test_dataset, cop23_data_pack_schema))
 
 

--- a/tests/testthat/test-unpackSNUxIM.R
+++ b/tests/testthat/test-unpackSNUxIM.R
@@ -376,22 +376,25 @@ test_that("Can identify negative mechanism target values", {
     "abc123", "HTS_TST.KP.Pos.T", NA, NA, "PWID", 10
   )
 
-  header_cols <- data.frame(indicator_code = c("PSNU"))
+  header_cols <- data.frame(indicator_code = c("PSNU", "indicator_code", "Age", "Sex", "KeyPop"))
 
   d <- testNegativeTargetValues(d,  header_cols)
   expect_true(is.data.frame(d$test$negative_IM_targets))
   expect_equal(NROW(d$tests$negative_IM_targets), 1L)
   expect_true(d$info$has_error)
-  expect_true(grepl("9999_DSD", d$info$messages$message))
+  expect_true(grepl("1 cases", d$info$messages$message))
+  expect_true(setequal(names(d$tests$negative_IM_targets),
+                       c("PSNU", "indicator_code",
+                         "Age", "Sex", "KeyPop", "mechCode_supportType", "value")))
+  expect_true(all(d$tests$negative_IM_targets$value < 0))
 
   #Note that this function remove negative targets, but does not remove the row
   ref <- tibble::tribble(
     ~"PSNU", ~"indicator_code", ~"Age", ~"Sex", ~"KeyPop", ~"9999_DSD",
-    "abc123", "HTS_TST.KP.Neg.T", NA, NA, "PWID", NA,
+    "abc123", "HTS_TST.KP.Neg.T", NA, NA, "PWID", NA_real_,
     "abc123", "HTS_TST.KP.Pos.T", NA, NA, "PWID", 10
   )
   expect_identical(d$data$SNUxIM, ref)
-
 
 })
 


### PR DESCRIPTION
## Developer:

<!---
**START HERE:**
1. All work in this PR should be reflected in a ticket(s) in Jira (Core Team) or GitHub (guests).
2. Update NEWS.md with changes.
3. Complete the below.
4. Assign Scott Jackson, Jason Pickering, or Sam Garman as Reviewer.
-->

### Summary of Proposed Changes
<!--- Bulleted description of what this code changes, adds, removes, or resolves in the package
- Adds functionality to allow...
- Resolves bug associated with...
- Removes redundant code in...
-->
- This PR relates to being able to run `devtools::check()` which provides additional code checks. It does not attempt to actually fix all of the issues which the checks reveal, but only seeks to allow us to run them. 
- Another reason for this PR is that `covr::report()` which calculates code coverage was not possible to be run either. Fixing the `devtools::check()` also allows the calculation of code coverage. 
- Due to reasons which are not clear, a refactor of the `testNegativeTargetValues` method and related test was undertaken. This check's test passed with `devtools::test()` but failed with `devtools::check()` . It is suspected this has to due with differences in library versions. The actual information available from this check was not as useful as it could be, so additional information has been added to allow users to more easily pinpoint the nature of the problem. 
- Additional refactoring was performed in the `helper.R` file. Due to differences in the package structure between the `test` and `check` procedures, the RDA/templates end up in different locations depending on which one is run. 

### Related Issues
- DP-1220

<!---
## Use GH labels (->) to indicate:
- Affected cycle (`cycle:`)
- Affected Tool (`tool:`)
- Affected Process Elements (`process:`)
- Types of changes (`type:`)
-->


## Reviewer:
- [x] Tests added/updated & passing.
- [x] Clean linting.
- [x] Related issue ticket in Jira/GitHub.
- [ ] Documentation added/updated.
- [x] Code conforms to style guidelines.
- [x] Well commented.
- [ ] Updates reflected in NEWS.md.
- [ ] Build check passes.
